### PR TITLE
Travis CI, master branch status on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # refractr [![Build Status](https://travis-ci.com/mozilla-it/refractr.svg?branch=master)](https://travis-ci.com/mozilla-it/refractr)
 yaml -> nginx for redirects and rewrites
 
+[![Build Status](https://travis-ci.com/mozilla-it/refractr.svg?branch=master)](https://travis-ci.com/mozilla-it/refractr)
+
 # Installing refractr in Kubernetes
 
 ## First install cert-manager if not already installed:


### PR DESCRIPTION
This pull request adds a Travis CI build badge to provide an indication of the "build-ability" of the master branch on the README page of the repository.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla-it/refractr/13)
<!-- Reviewable:end -->
