### PR TITLE
improve the fuzzy include search results

### DIFF
--- a/bin/refractr
+++ b/bin/refractr
@@ -87,6 +87,10 @@ def add_subparser(subparsers, action, **kwargs):
         type=int,
         help='positive integer? N items from top; negative? N items from back')
     parser.add_argument(
+        '-a', '--all-sources',
+        action='store_true',
+        help='toggle search for all sources instead of just first')
+    parser.add_argument(
         "patterns",
         nargs="*",
         default=["*"],
@@ -161,25 +165,29 @@ def main(args):
         output =refractr.show(
             parsed.patterns,
             parsed.only,
-            parsed.count)
+            parsed.count,
+            parsed.all_sources)
         yaml_print(output)
     elif parsed.action in ('do', 'domains'):
         domains = refractr.domains(
             parsed.patterns,
             parsed.only,
-            parsed.count)
+            parsed.count,
+            parsed.all_sources)
         yaml_print(domains)
     elif parsed.action in ('ngx', 'nginx'):
         output = refractr.render(
             parsed.patterns,
             parsed.only,
-            parsed.count)
+            parsed.count,
+            parsed.all_sources)
         print(output)
     elif parsed.action in ('ing', 'ingress'):
         domains = refractr.domains(
             parsed.patterns,
             parsed.only,
-            parsed.count)
+            parsed.count,
+            parsed.all_sources)
         env = Environment(
             loader=FileSystemLoader(os.path.dirname(parsed.ingress_template)),
             trim_blocks=True,
@@ -191,7 +199,8 @@ def main(args):
         validated = refractr.validate(
             parsed.patterns,
             parsed.only,
-            parsed.count)
+            parsed.count,
+            parsed.all_sources)
         yaml_print(validated)
 
 if __name__ == '__main__':

--- a/refractr/base.py
+++ b/refractr/base.py
@@ -5,17 +5,38 @@ from leatherman.yaml import yaml_format
 from refractr.url import URL
 from refractr.utils import *
 
+def tuplify(value):
+    if isinstance(value, dict):
+        return value
+    elif isinstance(value, (list, tuple)):
+        return tuple(value)
+    elif value != None:
+        return (value,)
+    return value
+
+def listify(obj):
+    if isinstance(obj, tuple):
+        return list(obj)
+    return obj
+
 class BaseRefract:
     def __init__(self, dsts=None, srcs=None, status=None, tests=None):
-        self.dsts = dsts
-        self.srcs = srcs
+        self.dsts = tuplify(dsts)
+        self.srcs = tuplify(srcs)
         self.status = status
-        self.tests = tests
+        self.tests = tuplify((tests or []) + self.generate_tests())
 
     def __str__(self):
         return yaml_format(self.json())
 
     __repr__ = __repr__
+
+    @property
+    def src(self):
+        if self.srcs:
+            assert isinstance(self.srcs, tuple) and len(self.srcs) > 0
+            return self.srcs[0]
+        return None
 
     @property
     def balance(self):
@@ -29,10 +50,10 @@ class BaseRefract:
 
     def json(self):
         return dict(
-            dsts=self.dsts,
-            srcs=self.srcs,
+            dsts=listify(self.dsts),
+            srcs=listify(self.srcs),
             status=self.status,
-            tests=self.tests
+            tests=listify(self.tests),
         )
 
     @property

--- a/refractr/complex.py
+++ b/refractr/complex.py
@@ -41,17 +41,20 @@ def create_test(src, path, target):
 
 class ComplexRefract(BaseRefract):
     def __init__(self, dsts, srcs, status, tests=None):
-        assert dsts and isinstance(dsts, list)
-        tests = tests or []
-        for src in srcs:
-            for dst in dsts:
+        super().__init__(dsts, srcs, status, tests)
+
+    def generate_tests(self):
+        assert self.dsts and isinstance(self.dsts, tuple), f'self.dsts={self.dsts}'
+        tests = []
+        for src in self.srcs:
+            for dst in self.dsts:
                 try:
                     path, target = head_body(dst)
                     if path.startswith('/'):
                         tests += [create_test(src, path, target)]
                 except:
                     continue
-        super().__init__(dsts, srcs, status, tests)
+        return tests
 
     def render_redirect(self, path, target, status=None, location=False):
         redirect = KeyMultiValueOption(

--- a/refractr/refractr.py
+++ b/refractr/refractr.py
@@ -15,6 +15,48 @@ from refractr.utils import *
 
 setup_yaml()
 
+def filter_only(refracts, only=None):
+    if only:
+        types = {
+            'nginx': NginxRefract,
+            'simple': SimpleRefract,
+            'complex': ComplexRefract,
+        }
+        return [
+            refract
+            for refract
+            in refracts
+            if isinstance(refract, types[only])
+        ]
+    return refracts
+
+def filter_sources(refracts, patterns, all_sources=False):
+    src_dict = {refract.src: refract for refract in refracts}
+    srcs_dict = {refract.srcs: refract for refract in refracts}
+    if all_sources:
+        return [
+            srcs_dict[srcs]
+            for srcs
+            in fuzzy(list(srcs_dict.keys())).include(*patterns)
+        ]
+    filtered = [
+        src_dict[src]
+        for src
+        in fuzzy(list(src_dict.keys())).include(*patterns)
+    ]
+    if filtered:
+        return filtered
+    return [
+        srcs_dict[srcs]
+        for srcs
+        in fuzzy(list(srcs_dict.keys())).include(*patterns)
+    ]
+
+def filter_count(refracts, count=None):
+    if refracts and count and abs(count) < len(refracts):
+        return refracts[:count] if count > 0 else refracts[count:]
+    return refracts
+
 class Refractr:
     def __init__(self, config=None, netloc=None, early=False, verbose=None, **kwargs):
         self.validator = RefractrValidator(netloc, early, verbose)
@@ -33,7 +75,7 @@ class Refractr:
         # this is a simple http->https redirect
         if isinstance(spec, str):
             # nginx ingress will give a 308 status code, not 301
-            return SimpleRefract(f'{spec}/', [spec], 308)
+            return SimpleRefract(f'{spec}/', spec, 308)
         tests = spec.pop('tests', None)
         nginx = spec.pop('nginx', None)
         if nginx:
@@ -43,41 +85,22 @@ class Refractr:
         status = spec.pop('status', 301)
         if len(spec) == 1:
             dsts, srcs = head_body(spec)
-        srcs = listify(srcs)
         if isinstance(dsts, list):
             return ComplexRefract(dsts, srcs, status, tests)
         return SimpleRefract(dsts, srcs, status)
 
-    def _filter(self, patterns=None, only=None, count=None):
+    def _filter(self, patterns=None, only=None, count=None, all_sources=False):
         if patterns == None:
             patterns = ['*']
-        if only:
-            # FIXME: filter on dsts targets if nothing found
-            types = {
-                'nginx': NginxRefract,
-                'simple': SimpleRefract,
-                'complex': ComplexRefract,
-            }
-            filtered = [
-                refract
-                for refract
-                in self.refracts
-                if isinstance(refract, types[only])
-            ]
-        else:
-            filtered = self.refracts
-        filtered = [
-            refract
-            for refract
-            in filtered
-            if fuzzy(refract.srcs).include(*patterns)
-        ]
-        if filtered and count and abs(count) < len(filtered):
-            filtered = filtered[:count] if count > 0 else filtered[count:]
+        # FIXME: filter on dsts targets if nothing found
+        filtered = self.refracts
+        filtered = filter_only(filtered, only)
+        filtered = filter_sources(filtered, patterns, all_sources)
+        filtered = filter_count(filtered, count)
         return filtered
 
-    def show(self, patterns=None, only=None, count=False):
-        refracts = self._filter(patterns, only, count)
+    def show(self, patterns=None, only=None, count=None, all_sources=False):
+        refracts = self._filter(patterns, only, count, all_sources)
         return {
             'refracts': [
                 refract.json()
@@ -87,8 +110,8 @@ class Refractr:
             'refracts-count': len(refracts)
         }
 
-    def domains(self, patterns=None, only=None, count=False):
-        refracts = self._filter(patterns, only, count)
+    def domains(self, patterns=None, only=None, count=None, all_sources=False):
+        refracts = self._filter(patterns, only, count, all_sources)
         domains = sorted(list(set(chain(*[
             refract.srcs
             for refract
@@ -99,8 +122,8 @@ class Refractr:
             'domains-count': len(domains),
         }
 
-    def render(self, patterns=None, only=None, count=False):
-        refracts = self._filter(patterns, only, count)
+    def render(self, patterns=None, only=None, count=None, all_sources=False):
+        refracts = self._filter(patterns, only, count, all_sources)
         stanzas = list(chain(*[
             refract.render()
             for refract
@@ -113,7 +136,7 @@ class Refractr:
             in stanzas
         ])
 
-    def validate(self, patterns=None, only=None, count=None):
-        refracts = self._filter(patterns, only, count)
+    def validate(self, patterns=None, only=None, count=None, all_sources=False):
+        refracts = self._filter(patterns, only, count, all_sources)
         validation = self.validator.validate_refracts(refracts)
         return validation

--- a/refractr/simple.py
+++ b/refractr/simple.py
@@ -7,12 +7,19 @@ from refractr.url import URL
 
 class SimpleRefract(BaseRefract):
     def __init__(self, dsts, srcs, status):
-        tests = [
-            {URL(src).http: URL(dsts).https}
+        super().__init__(dsts, srcs, status)
+
+    @property
+    def dst(self):
+        assert self.dsts and len(self.dsts) == 1, f'self.dsts={self.dsts}'
+        return self.dsts[0]
+
+    def generate_tests(self):
+        return [
+            {URL(src).http: URL(self.dst).https}
             for src
-            in srcs
+            in self.srcs
         ]
-        super().__init__(dsts, srcs, status, tests)
 
     def render(self):
         server_name = KeyValueOption('server_name', self.server_name)
@@ -22,7 +29,7 @@ class SimpleRefract(BaseRefract):
             KeyMultiValueOption(
                 'return', [
                     self.status,
-                    URL(self.dsts).https
+                    URL(self.dst).https
                 ]
             )
         )]

--- a/refractr/url.py
+++ b/refractr/url.py
@@ -1,6 +1,7 @@
 from urllib.parse import urlparse, ParseResult
 from collections import UserString
 from refractr.exceptions import URLError
+from refractr.utils import *
 
 # makes visualizing as string easier to read
 ParseResult.__repr__ = lambda self: self.geturl()

--- a/refractr/utils.py
+++ b/refractr/utils.py
@@ -21,15 +21,6 @@ def startswith(s, *tests):
     result = any([s.startswith(test) for test in tests])
     return result
 
-def listify(value):
-    if isinstance(value, dict):
-        return value
-    elif isinstance(value, (list, tuple)):
-        return list(value)
-    elif value != None:
-        return [value]
-    return value
-
 def join(items, sep=' '):
     return sep.join(items)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 doit
 black
 ruamel.yaml
-leatherman==0.1.7
+leatherman==0.1.10
 pytest==5.3.2
 nginx-config-builder==1.0.1
 aiohttp==3.6.2


### PR DESCRIPTION
- made sure dsts, srcs and tests are stored as tuples
- bumped leatherman.fuzzy to v0.0.10 to sort on list of lists
- used improved leatherman.fuzzy searching to improve matches on patterns
- added --all-sources option to pattern matches, but first server_name
  the default
- broke out generate_tests for Single and Complex Refracts