### PR TITLE
Update ingress apiVersion

### DIFF
--- a/refractr/ingress.yaml.template
+++ b/refractr/ingress.yaml.template
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:


### PR DESCRIPTION
Update `ingress` object `apiVersion`, since kubernetes 1.16 the api `extentions/v1beta1` has been removed so  we're switching over to the new api

See: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/