### PR TITLE
added preserve_path feature for firefox.com

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -284,6 +284,7 @@ refracts:
   # Jira SE-1258 "Setup firefox.com to redirect to www.firefox.com"
   # This is LE Blacklisted; needs to be removed
 - www.firefox.com/: firefox.com
+  preserve_path: true
 
   # bug 1136318
   # NOTE: changed from http->https after verifying

--- a/refractr/base.py
+++ b/refractr/base.py
@@ -20,10 +20,11 @@ def listify(obj):
     return obj
 
 class BaseRefract:
-    def __init__(self, dsts=None, srcs=None, status=None, tests=None):
+    def __init__(self, dsts=None, srcs=None, status=None, preserve_path=False, tests=None):
         self.dsts = tuplify(dsts)
         self.srcs = tuplify(srcs)
         self.status = status
+        self.preserve_path = preserve_path
         self.tests = tuplify((tests or []) + self.generate_tests())
 
     def __str__(self):
@@ -53,6 +54,7 @@ class BaseRefract:
             dsts=listify(self.dsts),
             srcs=listify(self.srcs),
             status=self.status,
+            preserve_path=self.preserve_path,
             tests=listify(self.tests),
         )
 

--- a/refractr/complex.py
+++ b/refractr/complex.py
@@ -40,8 +40,8 @@ def create_test(src, path, target):
     }
 
 class ComplexRefract(BaseRefract):
-    def __init__(self, dsts, srcs, status, tests=None):
-        super().__init__(dsts, srcs, status, tests)
+    def __init__(self, dsts, srcs, status, preserve_path, tests=None):
+        super().__init__(dsts, srcs, status, preserve_path, tests)
 
     def generate_tests(self):
         assert self.dsts and isinstance(self.dsts, tuple), f'self.dsts={self.dsts}'
@@ -60,7 +60,8 @@ class ComplexRefract(BaseRefract):
         redirect = KeyMultiValueOption(
             'return', [
                 status or self.status,
-                URL(target),
+                # NOTE: this wasn't suffixed with .https; adding that now
+                URL(target).https,
             ]
         )
         if location:
@@ -74,7 +75,7 @@ class ComplexRefract(BaseRefract):
         rewrite = KeyMultiValueOption(
             'rewrite', [
                 match,
-                URL(target).https,
+                URL(target, self.preserve_path).https,
                 status_to_word(status or self.status),
             ]
         )

--- a/refractr/refractr.py
+++ b/refractr/refractr.py
@@ -84,11 +84,12 @@ class Refractr:
         dsts = spec.pop('dsts', None)
         srcs = spec.pop('srcs', None)
         status = spec.pop('status', 301)
+        preserve_path = spec.pop('preserve_path', False)
         if len(spec) == 1:
             dsts, srcs = head_body(spec)
         if isinstance(dsts, list):
-            return ComplexRefract(dsts, srcs, status, tests)
-        return SimpleRefract(dsts, srcs, status)
+            return ComplexRefract(dsts, srcs, status, preserve_path, tests)
+        return SimpleRefract(dsts, srcs, status, preserve_path)
 
     def _filter(self, patterns=None, only=None, count=None, all_sources=False):
         if patterns == None:

--- a/refractr/schema.yml
+++ b/refractr/schema.yml
@@ -103,7 +103,7 @@ defs:
     title: test
     type: object
     minProperties: 1
-    maxProperties: 2
+    maxProperties: 3
     additionalProperties: false
     patternProperties:
       '^(https?:\/\/)([A-z0-9]+([A-z0-9\.\-]+)\/)([A-z0-9\-_]+\/)*([A-z0-9$\/\.\-_:]+)?(\?[A-z0-9$\.\-:=]+(&[A-z0-9$\.\-:=]+)*)?(#[A-z0-9\-_]+)?$':
@@ -111,6 +111,8 @@ defs:
     properties:
       status:
         type: integer
+      preserve_path:
+        type: boolean
   tests:
     default: []
     title: tests
@@ -135,11 +137,13 @@ defs:
     title: simple-refract
     type: object
     minProperties: 1
-    maxProperties: 2
+    maxProperties: 3
     additionalProperties: false
     properties:
       status:
         type: integer
+      preserve_path:
+        type: boolean
     patternProperties:
       # same as #/defs/dst-url
       '^(?!https?:\/\/)([A-z0-9]+([A-z0-9\.\-]+)\/)([A-z0-9\-_]+\/)*([A-z0-9$\/\.\-_:]+)?(\?[A-z0-9$\.\-:=]+(&[A-z0-9$\.\-:=]+)*)?(#[A-z0-9\-_]+)?$':
@@ -165,5 +169,7 @@ defs:
         $ref: '#/defs/dsts'
       status:
         type: integer
+      preserve_path:
+        type: boolean
       tests:
         $ref: '#/defs/tests'

--- a/refractr/simple.py
+++ b/refractr/simple.py
@@ -6,8 +6,8 @@ from refractr.base import BaseRefract
 from refractr.url import URL
 
 class SimpleRefract(BaseRefract):
-    def __init__(self, dsts, srcs, status):
-        super().__init__(dsts, srcs, status)
+    def __init__(self, dsts, srcs, status, preserve_path):
+        super().__init__(dsts, srcs, status, preserve_path)
 
     @property
     def dst(self):
@@ -15,21 +15,29 @@ class SimpleRefract(BaseRefract):
         return self.dsts[0]
 
     def generate_tests(self):
-        return [
+        tests = [
             {URL(src).http: URL(self.dst).https}
             for src
             in self.srcs
         ]
+        if self.preserve_path:
+            tests += [
+                {URL(src, path='path').http: URL(self.dst, path='path').https}
+                for src
+                in self.srcs
+            ]
+        return tests
 
     def render(self):
         server_name = KeyValueOption('server_name', self.server_name)
+        target = URL(self.dst)
         return [Section(
             'server',
             server_name,
             KeyMultiValueOption(
                 'return', [
                     self.status,
-                    URL(self.dst).https
+                    URL(self.dst, self.preserve_path).https,
                 ]
             )
         )]

--- a/tests/test_refractr.py
+++ b/tests/test_refractr.py
@@ -24,4 +24,4 @@ def test_refract(refract):
     assert isinstance(refract, BaseRefract)
     validation = validator.validate_refract(refract)
     yaml_print(dict(validation=validation))
-    assert validation['validate-result'] == SUCCESS_RESULT
+    assert validation['validate-result'] == SUCCESS_RESULT, validation


### PR DESCRIPTION
- nginx doesnt preserve the path during redirect like Apache does
- added 'preserve_path' boolean option for simple and complex refracts
- changed schema to allow this new field
- wired nginx generation code to replace '/' with $request_uri if
  toggled
- wired test generation code to add '/path' per domain if toggled