### PR TITLE
Redirect testpilot.firefox.com to fpn.firefox.com

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -126,6 +126,8 @@ refracts:
   - mozillafoundation.com
   - mozillafoundation.net
 
+- fpn.firefox.com/: testpilot.firefox.com
+
   # bug 1334200
 - github.com/mozilla/popcorn-js/:
   - popcornjs.org


### PR DESCRIPTION
Replacing #150 