### PR TITLE
Update redirection to new URL; Saves 1 hop

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -259,7 +259,7 @@ refracts:
   - videos.mozilla.org
 
   # bug 1614193
-- voice.mozilla.org/fy-NL/: voice.mozilla.frl
+- commonvoice.mozilla.org/fy-NL/: voice.mozilla.frl
   status: 302
 
   # bug 1419948


### PR DESCRIPTION
Reported in this bug https://bugzilla.mozilla.org/show_bug.cgi?id=1666460, we want to update the redirection to the new URL, saving one hop