### PR TITLE
Add use-application-dns.net

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -253,6 +253,10 @@ refracts:
   # bug 835529
 - support.mozilla.org/: www.support.mozilla.org
 
+  # SE-1564
+- support.mozilla.org/en-US/kb/canary-domain-use-application-dnsnet:  use-application-dns.net
+
+
   # bug 20170327
 - videos.cdn.mozilla.net/:
   - videos-cdn.mozilla.net


### PR DESCRIPTION
The DNS response for this domain is used to test if DoH should be
enabled or not. We're setting up a redirect in case someone is curious
and tries to access it in their browser. For more details, see
https://jira.mozilla.com/browse/SE-1564

This is being migrated from the datacenter redirects cluster to
refractr.