### PR TITLE
Redirect foro.mozilla-hispano.org to discourse

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -76,6 +76,9 @@ refracts:
   - mozilla-hispano.org
   - www.mozilla-hispano.org
 
+  # bug 1697571
+  - discourse.mozilla.org/c/community-portal/mozilla-hispano/304: foro.mozilla-hispano.org
+
   # bug 1697638
 - community.mozilla.org/es/groups/mozilla-venezuela/: 
   - mozillavenezuela.org


### PR DESCRIPTION
We missed this when doing the redirects earlier.