### PR TITLE
Support releases that use lightweight tags

### DIFF
--- a/refractr/cfg.py
+++ b/refractr/cfg.py
@@ -198,7 +198,7 @@ class AutoConfigPlus(AutoConfig):  # pylint: disable=too-many-public-methods
     @lru_cache()
     def VERSION(self):
         try:
-            return git('describe --abbrev=7 --always')
+            return git('describe --abbrev=7 --always --tags')
         except (NotGitRepoError, GitCommandNotFoundError):
             return self('VERSION')
 


### PR DESCRIPTION
Without this, only annotated tags are considered when generating the
name to tag the docker image with.