### PR TITLE
Moving this config value out a block

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -77,7 +77,7 @@ refracts:
   - www.mozilla-hispano.org
 
   # bug 1697571
-  - discourse.mozilla.org/c/community-portal/mozilla-hispano/304: foro.mozilla-hispano.org
+- discourse.mozilla.org/c/community-portal/mozilla-hispano/304: foro.mozilla-hispano.org
 
   # bug 1697638
 - community.mozilla.org/es/groups/mozilla-venezuela/: 


### PR DESCRIPTION
It was failing tests because it looks like it was being associated with the
redirect above, breaking the tests.