### PR TITLE
Redirect ideas.mozilla.org to crowdicity

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -185,6 +185,9 @@ refracts:
   - mozdev.org
   - www.mozdev.org
 
+  # SE-1561
+- mozilla.crowdicity.com/: ideas.mozilla.org
+
   # bug 1335596
   # NOTE: changed redirect to its final destination
 - mozilla.design/: designlanguage.mozilla.org


### PR DESCRIPTION
This was requested in https://jira.mozilla.com/browse/SE-1651

I have already configured DNS

```
$ host ideas.mozilla.org
ideas.mozilla.org is an alias for prod.refractr.mozit.cloud.
```