### PR TITLE
remove extranet.mozilla.org to mozilla.grouphub.com redirect

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -205,8 +205,6 @@ refracts:
 
 - mozilla.github.io/oi-website/: openinnovation.mozilla.org
 
-- mozilla.grouphub.com/: extranet.mozilla.org
-
   # jira SE-1295
 - mozilla.hosted.panopto.com/:
   - air.mozilla.org


### PR DESCRIPTION
See https://jira.mozilla.com/browse/SE-1682

Checklist:

- [x] TLS cert request? - not needed here
- [x] DNS creation or change request? - not needed here (already removed)
- [x] update prod.refractr.yaml
- [x] test locally generation of nginx config via dev.refractr.yaml
- [x] test locally the generated Docker image with above configurations