### PR TITLE
adding addons.mozilla.com -> addons.mozilla.org rewrite

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -16,6 +16,9 @@ refracts:
   - activations.mozilla.com
   - activations.mozilla.org
 
+  # SE-1683
+- addons.mozilla.org/: addons.mozilla.com
+
   # bug 503731, 528747, 537144
 - addons.mozilla.org/:
   - extensions.mozilla.org

--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -14,12 +14,9 @@ refracts:
   # bug 998357
 - activations.cdn.mozilla.net/:
   - activations.mozilla.com
-  - activations.mozilla.org
+  - activations.mozilla.org 
 
-  # SE-1683
-- addons.mozilla.org/: addons.mozilla.com
-
-  # bug 503731, 528747, 537144
+  # bug 503731, 528747, 537144, SE-1683
 - addons.mozilla.org/:
   - extensions.mozilla.org
   - themes.mozilla.org
@@ -28,6 +25,7 @@ refracts:
   - addons.update.mozilla.org
   - firefoxaddons.com
   - www.firefoxaddons.com
+  - addons.mozilla.com
 
   # bug 1342698
   # NOTE: changed from http->https after verifying


### PR DESCRIPTION
JIRA ticket: https://jira.mozilla.com/browse/SE-1683

- [x] **TLS cert concerns**? Yes, this is an existing service, and [it is not covered by the DNS / CNAME solver domains list ](https://github.com/mozilla-it/itse-apps-prod-1-infra/blob/bb9b965e496cac73ad2ca8aa9c42ebdcccbb776a/k8s/releases/refractr/refractr.yaml#L27)we have currently, so there will be some time between the DNS pointing to refractr and the LE HTTP01 default solver working to get addons.mozilla.com a cert. Next step I believe is to ask @sciurus and/or the original requester if a cert outage period is acceptable
- [x] **DNS creation or change request**? This will require a CNAME record pointing addons.mozilla.org to refractr. To be done with Rob.
- [x] update prod.refractr.yaml
- [x] test locally generation of nginx config via dev.refractr.yaml
- [x] test locally the generated Docker image with above configurations
- [x] connected to EKS to watch release