### PR TITLE
redirect InHumanAds.com to www.mozilla.org

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -389,6 +389,8 @@ refracts:
   - mobilepartners.mozilla.org
   # bug 1329125
   - masterfirefoxos.mozilla.org
+  # SE-1224
+  - inhumanads.com
   status: 302
 
 - www.mozilla.org/: mozilla-podcasts.org


### PR DESCRIPTION
What this PR does: Redirect inhumanads.com to www.mozilla.org

## Refractr PR Checklist

JIRA ticket: https://jira.mozilla.com/browse/SE-1224

When creating a PR for Refractr, confirm you've done the following steps for smooth CI and CD experiences:
- [x] Have you updated the relevant YAML in the PR?
- [x] Have you checked if there are any TLS cert concerns - e.g. if the domain being redirected already exists, and it is being changed to point at Refractr, is a temporary TLS 'outage' while waiting for Lets Encrypt certification via HTTP challenge okay? If not, [have you followed these steps for using DNS challenges with our cert-manager setup](https://mana.mozilla.org/wiki/display/SRE/Refractr+-+How+To+-+DNS+Challenges)?
- [x] If desired, have you generated the Nginx manually to confirm addition works as expected? 
- [x] If desired, are you able to connect to EKS (cluster itse-apps-prod-1, namespace fluxcd) to more closely monitor the deploys?

After PR merge, next steps include:
- [ ] If going straight from main merge & Stage deploy to a release & production deploy, create the relevant GitHub release with an incremented version / tag applied.
- [ ] Confirm you are ready and able to perform the requested DNS creation or change post-deploy? 
