### PR TITLE
add list of domains identified by gcox to redirect to firefox

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -511,6 +511,25 @@ refracts:
   - downloadmozillafirefox.com
   # bug 948963
   - spark.mozilla.org
+  # SE-1862
+  - boot2gecko.net
+  - www.boot2gecko.net
+  - firefoxos.com
+  - www.firefoxos.com
+  - firefox-academic-centers.org
+  - www.firefox-academic-centers.org
+  - firefox-academic-centers.com
+  - www.firefox-academic-centers.com
+  - firefox-academic-center.org
+  - www.firefox-academic-center.org
+  - firefox-academic-center.com
+  - www.firefox-academic-center.com
+  - mozillaservice.org
+  - www.mozillaservice.org
+  - opentochoice.org
+  - www.opentochoice.org
+  - onebillionplusyou.com
+  - www.onebillionplusyou.com
   status: 302
 
   # bug 1351245


### PR DESCRIPTION
## Refractr PR Checklist

JIRA ticket: https://jira.mozilla.com/browse/SE-1862

Note: gcox found a list of domains needing to be mapped over to refractr. See ticket for list. Added domain plus www.domain given some looking at what infoblox records exist now.

When creating a PR for Refractr, confirm you've done the following steps for smooth CI and CD experiences:
- [x] Have you updated the relevant YAML in the PR?
- [x] Have you checked if there are any TLS cert concerns - e.g. if the domain being redirected already exists, and it is being changed to point at Refractr, is a temporary TLS 'outage' while waiting for Lets Encrypt certification via HTTP challenge okay? If not, [have you followed these steps for using DNS challenges with our cert-manager setup](https://mana.mozilla.org/wiki/display/SRE/Refractr+-+How+To+-+DNS+Challenges)?
- [x] If desired, have you generated the Nginx manually to confirm addition works as expected? 
- [x] If desired, are you able to connect to EKS (cluster itse-apps-prod-1, namespace fluxcd) to more closely monitor the deploys?

After PR merge, next steps include:
- [ ] If going straight from main merge & Stage deploy to a release & production deploy, create the relevant GitHub release with an incremented version / tag applied.
- [x] Confirm you are ready and able to perform the requested DNS creation or change post-deploy? - *gcox said he would handle this.*
