### PR TITLE
Update and clean up dependencies.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,13 @@
 doit
-black
 ruamel.yaml
 leatherman==0.1.10
 pytest==6.1.1
 nginx-config-builder==1.0.1
-aiohttp==3.6.3
-jinja2==2.11.2
-pyyaml==5.3.1
+aiohttp==3.7.4.post0
+jinja2==2.11.3
 jsonschema==3.2.0
 python-decouple==3.3
 tldextract==3.0.0
+
+# Not used directly; only included to fix a compatible version
+idna==2.10


### PR DESCRIPTION
This fixes the dependabot warnings shown on the repo page, and also cleans up the requirements file a bit.

* `black` and `pyyaml` are unused in the whole code base, so I removed them.
* Minor version upgrades for `aiohttp` and `jinja2` to fix dependabot warnings. I read the changelog and ran the tests to make sure this doesn't break anything.
* Fix `idna` version. This package isn't directly needed by the code in this repository. It's a transitive dependency via multiple paths, though, and pip does not resolve the version correctly if we don't specify it here.

I'll file issues for a few further improvements I'd suggest on Jira.