### PR TITLE
comment out stage domains that dont point to refractr

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # refractr [![Build Status](https://travis-ci.com/mozilla-it/refractr.svg?branch=main)](https://travis-ci.com/mozilla-it/refractr)
+
 Containerized HTTP redirect and rewrite service with automatic Let's Encrypt SSL certs
 
 [![Build Status](https://travis-ci.com/mozilla-it/refractr.svg?branch=main)](https://travis-ci.com/mozilla-it/refractr)

--- a/stage-refractr.yml
+++ b/stage-refractr.yml
@@ -19,6 +19,7 @@ refracts:
 
 - mozilla.org/: refractr2.allizom.org
 
-- mozilla.org/:
-  - malware-error.allizom.org
-  - '*.malware-error.allizom.org'
+# this domain doesn't point to refractr atm
+# - mozilla.org/:
+#   - malware-error.allizom.org
+#   - '*.malware-error.allizom.org'


### PR DESCRIPTION
Confirming stage deploy okay after out-of-band, ingress-nginx helm-managed ValidatingWebHookConfiguration resource removed from test namespace work.