### PR TITLE
SE-2237 Redirect for www.mozilla.ch

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -366,6 +366,8 @@ refracts:
 - www.mozilla.org/:
   # bug 1598043
   - mozilla.ch
+  # bug 1660250
+  # jira SE-2237
   - www.mozilla.ch
   # bug 1559362
   - mozilla-uk.org

--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -366,6 +366,7 @@ refracts:
 - www.mozilla.org/:
   # bug 1598043
   - mozilla.ch
+  - www.mozilla.ch
   # bug 1559362
   - mozilla-uk.org
   #- virtual-redirect-mozilla.org FIXME: NXDOMAIN


### PR DESCRIPTION
# Description

Based on https://bugzilla.mozilla.org/show_bug.cgi?id=1598043 I believe we can now redirect www.mozilla.ch to mozilla.org. DNS is already pointing at refractr. The `www` subdomain currently 404s. Certificate offered from the `www` subdomain is a generic k8s ingress certificate.

## Refractr PR Checklist

JIRA ticket: [https://mozilla-hub.atlassian.net/browse/SE-2237]

When creating a PR for Refractr, confirm you've done the following steps for smooth CI and CD experiences:
- [X] Have you updated the relevant YAML in the PR?

Hopefully.

- [X] Have you checked if there are any TLS cert concerns - e.g. if the domain being redirected already exists, and it is being changed to point at Refractr, is a temporary TLS 'outage' while waiting for Lets Encrypt certification via HTTP challenge okay? If not, [have you followed these steps for using DNS challenges with our cert-manager setup](https://mana.mozilla.org/wiki/display/SRE/Refractr+-+How+To+-+DNS+Challenges)?

DNS already pointed at refractr and the subdomain `www.` 404s. Any outage for certificate here should be fine as it is not working right now.

- [X] If desired, have you generated the Nginx manually to confirm addition works as expected?

I generated the config and looked at it. It looks correct to me.

- [X] If desired, are you able to connect to EKS (cluster itse-apps-prod-1, namespace fluxcd) to more closely monitor the deploys?

Yes, I certainly can

After PR merge, next steps include:
- [ ] If going straight from main merge & Stage deploy to a release & production deploy, create the relevant GitHub release with an incremented version / tag applied.
- [ ] Confirm you are ready and able to perform the requested DNS creation or change post-deploy?

DNS is already created and pointing at refractr. 
