### PR TITLE
Redirect techspeakers to community portal

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -768,3 +768,9 @@ refracts:
 
 - mozilla-hub.atlassian.net/: jira.mozilla.com
   status: 302
+
+  # bug 1660250
+- dsts:
+  - /: community.mozilla.org/en/groups/tech-speakers/
+  srcs:
+  - techspeakers.mozilla.org

--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -770,7 +770,4 @@ refracts:
   status: 302
 
   # bug 1660250
-- dsts:
-  - /: community.mozilla.org/en/groups/tech-speakers/
-  srcs:
-  - techspeakers.mozilla.org
+- community.mozilla.org/en/groups/tech-speakers/: techspeakers.mozilla.org


### PR DESCRIPTION
This is a request we received through [Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1660250).
techspeakers.mozilla.org currently resolves to refractr but 404s. This will redirect the url to the community portal.

```sh
server {
    server_name techspeakers.mozilla.org;
    add_header Strict-Transport-Security "max-age=60; includeSubDomains"
always;
    location = / {
        return 301
https://community.mozilla.org/en/groups/tech-speakers/;
    }
}
```

## Refractr PR Checklist

JIRA ticket: [link to relevant JIRA or other system ticket]

When creating a PR for Refractr, confirm you've done the following steps for smooth CI and CD experiences:
- [X] Have you updated the relevant YAML in the PR?
- [X] Have you checked if there are any TLS cert concerns - e.g. if the domain being redirected already exists, and it is being changed to point at Refractr, is a temporary TLS 'outage' while waiting for Lets Encrypt certification via HTTP challenge okay? If not, [have you followed these steps for using DNS challenges with our cert-manager setup](https://mana.mozilla.org/wiki/display/SRE/Refractr+-+How+To+-+DNS+Challenges)?
Looks like other  refractrs are pointing to community.mozilla.org so I think that should be okay. It isn't controlled by refractr.

- [X] If desired, have you generated the Nginx manually to confirm addition works as expected? 
Yep, shown above.

- [X] If desired, are you able to connect to EKS (cluster itse-apps-prod-1, namespace fluxcd) to more closely monitor the deploys?
Definitely.

After PR merge, next steps include:
- [ ] If going straight from main merge & Stage deploy to a release & production deploy, create the relevant GitHub release with an incremented version / tag applied.
- [ ] Confirm you are ready and able to perform the requested DNS creation or change post-deploy? 
