### PR TITLE
techspeakers.mozilla.org redirected twice

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,7 @@ JIRA ticket: [link to relevant JIRA or other system ticket]
 
 When creating a PR for Refractr, confirm you've done the following steps for smooth CI and CD experiences:
 - [ ] Have you updated the relevant YAML in the PR?
+- [ ] Have you checked the relevant YAML for any possible dupes regarding your domain?
 - [ ] Have you checked if there are any TLS cert concerns - e.g. if the domain being redirected already exists, and it is being changed to point at Refractr, is a temporary TLS 'outage' while waiting for Lets Encrypt certification via HTTP challenge okay? If not, [have you followed these steps for using DNS challenges with our cert-manager setup](https://mana.mozilla.org/wiki/display/SRE/Refractr+-+How+To+-+DNS+Challenges)?
 - [ ] If desired, have you generated the Nginx manually to confirm addition works as expected? 
 - [ ] If desired, are you able to connect to EKS (cluster itse-apps-prod-1, namespace fluxcd) to more closely monitor the deploys?

--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -135,9 +135,15 @@ refracts:
   # SE-1371
 - searchfox.org/:  dxr.mozilla.org
 
-  # bug 1502902
-  # FIXME: valid anymore, considering the redirects below?
-- events.mozilla.org/techspeakers/: techspeakers.mozilla.org
+  # bug 1502902 (formerly events.mozilla.org/techspeakers/)
+  # bug 1660250
+- community.mozilla.org/en/groups/tech-speakers/:
+  - techspeakers.mozilla.org
+
+  # bug 1660250
+- dsts:
+  - /communities/mozilla-tech-speakers: community.mozilla.org/en/groups/tech-speakers/
+  srcs: developer.mozilla.com
 
   # bug 1195576
   # FIXME: this commented out redirect is incorrect, added correct one below
@@ -774,6 +780,3 @@ refracts:
 
 - mozilla-hub.atlassian.net/: jira.mozilla.com
   status: 302
-
-  # bug 1660250
-- community.mozilla.org/en/groups/tech-speakers/: techspeakers.mozilla.org


### PR DESCRIPTION
## Refractr PR Checklist

JIRA ticket: SE-2238, https://bugzilla.mozilla.org/show_bug.cgi?id=1660250

Note: PR repairs techspeakers.mozilla.org being redirected twice, plus missing other redirect request in bugzilla ticket (developer.mozilla.com/communities/mozilla-tech-speakers)

When creating a PR for Refractr, confirm you've done the following steps for smooth CI and CD experiences:
- [x] Have you updated the relevant YAML in the PR?
- [x] Have you checked if there are any TLS cert concerns - e.g. if the domain being redirected already exists, and it is being changed to point at Refractr, is a temporary TLS 'outage' while waiting for Lets Encrypt certification via HTTP challenge okay? If not, [have you followed these steps for using DNS challenges with our cert-manager setup](https://mana.mozilla.org/wiki/display/SRE/Refractr+-+How+To+-+DNS+Challenges)?
- [x] If desired, have you generated the Nginx manually to confirm addition works as expected? 
- [x] If desired, are you able to connect to EKS (cluster itse-apps-prod-1, namespace fluxcd) to more closely monitor the deploys?

After PR merge, next steps include:
- [x] If going straight from main merge & Stage deploy to a release & production deploy, create the relevant GitHub release with an incremented version / tag applied.
- [x] Confirm you are ready and able to perform the requested DNS creation or change post-deploy? 
