### PR TITLE
add note for MDN-managed redirects

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,7 @@
 JIRA ticket: [link to relevant JIRA or other system ticket]
 
 When creating a PR for Refractr, confirm you've done the following steps for smooth CI and CD experiences:
+- [ ] Is this the right place for your redirect (e.g. developer.mozilla.com/* redirects should be managed by MDN; other examples here as known)?
 - [ ] Have you updated the relevant YAML in the PR?
 - [ ] Have you checked the relevant YAML for any possible dupes regarding your domain?
 - [ ] Have you checked if there are any TLS cert concerns - e.g. if the domain being redirected already exists, and it is being changed to point at Refractr, is a temporary TLS 'outage' while waiting for Lets Encrypt certification via HTTP challenge okay? If not, [have you followed these steps for using DNS challenges with our cert-manager setup](https://mana.mozilla.org/wiki/display/SRE/Refractr+-+How+To+-+DNS+Challenges)?

--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -140,11 +140,6 @@ refracts:
 - community.mozilla.org/en/groups/tech-speakers/:
   - techspeakers.mozilla.org
 
-  # bug 1660250
-- dsts:
-  - /communities/mozilla-tech-speakers: community.mozilla.org/en/groups/tech-speakers/
-  srcs: developer.mozilla.com
-
   # bug 1195576
   # FIXME: this commented out redirect is incorrect, added correct one below
   #- mozillafoundation.org:


### PR DESCRIPTION
## Refractr PR Checklist

JIRA ticket: SE-2238 repair 2, bugzilla https://bugzilla.mozilla.org/show_bug.cgi?id=1660250

Note: PR adds note for MDN-managed redirects to PR checklist

When creating a PR for Refractr, confirm you've done the following steps for smooth CI and CD experiences:
- [x] Have you updated the relevant YAML in the PR?
- [x] Have you checked the relevant YAML for any possible dupes regarding your domain?
- [x] Have you checked if there are any TLS cert concerns - e.g. if the domain being redirected already exists, and it is being changed to point at Refractr, is a temporary TLS 'outage' while waiting for Lets Encrypt certification via HTTP challenge okay? If not, [have you followed these steps for using DNS challenges with our cert-manager setup](https://mana.mozilla.org/wiki/display/SRE/Refractr+-+How+To+-+DNS+Challenges)?
- [x] If desired, have you generated the Nginx manually to confirm addition works as expected? 
- [x] If desired, are you able to connect to EKS (cluster itse-apps-prod-1, namespace fluxcd) to more closely monitor the deploys?

After PR merge, next steps include:
- [x] If going straight from main merge & Stage deploy to a release & production deploy, create the relevant GitHub release with an incremented version / tag applied.
- [x] Confirm you are ready and able to perform the requested DNS creation or change post-deploy? 
