### PR TITLE
getpersonas.com & www.getpersonas.com paths rewrites

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -704,6 +704,44 @@ refracts:
   srcs: reps.mozilla.org
   status: 307
 
+  # SE-2412
+- dsts:
+  - if: '$request_uri ~ "^/update_check/(?<id>\d+)"'
+    ^.*$: 'versioncheck.addons.mozilla.org/en-US/themes/update-check/$id?src=gp'
+  - if: '$request_uri ~ "^(?<id>(?:/\w{2,3}(?:-\w{2,6})?))/update_check/(?<update_id>\d+)"'
+    ^.*$: 'versioncheck.addons.mozilla.org$id/themes/update-check/$update_id?src=gp'
+  - if: '$request_uri ~ "^(?:/\w{2,3}(?:-\w{2,6})?)?/gallery/[Dd]esigner/(?<id>.*)"'
+    ^.*$: 'addons.mozilla.org/firefox/user/$id/'
+  - if: '$request_uri ~ "^(?:/\w{2,3}(?:-\w{2,6})?)?/persona/(?<id>\d+)"'
+    ^.*$: 'addons.mozilla.org/persona/$id'
+  - if: '$request_uri ~ "^(?:/\w{2,3}(?:-\w{2,6})?)?/gallery/All/Movers"'
+    ^.*$: 'addons.mozilla.org/firefox/themes/?sort=up-and-coming'
+  - if: '$request_uri ~ "^(?:/\w{2,3}(?:-\w{2,6})?)?/gallery/All/Recent"'
+    ^.*$: 'addons.mozilla.org/firefox/themes/?sort=created'
+  - if: '$request_uri ~ "^(?:/\w{2,3}(?:-\w{2,6})?)?/gallery/All/Popular"'
+    ^.*$: 'addons.mozilla.org/firefox/themes/?sort=popular'
+  - redirect: addons.mozilla.org/themes/
+  srcs:
+  - getpersonas.com
+  - www.getpersonas.com
+  tests:
+  - http://getpersonas.com/update_check/1234: 'https://versioncheck.addons.mozilla.org/en-US/themes/update-check/1234?src=gp'
+  - http://www.getpersonas.com/update_check/5678: 'https://versioncheck.addons.mozilla.org/en-US/themes/update-check/5678?src=gp'
+  - http://getpersonas.com/a_c-12_d/update_check/1234: 'https://versioncheck.addons.mozilla.org/a_c-12_d/themes/update-check/1234?src=gp'
+  - http://www.getpersonas.com/a_c-12_d/update_check/12345678: 'https://versioncheck.addons.mozilla.org/a_c-12_d/themes/update-check/12345678?src=gp'
+  - http://getpersonas.com/a_c/gallery/Designer/something: 'https://addons.mozilla.org/firefox/user/something/'
+  - http://www.getpersonas.com/a_c/gallery/designer/something: 'https://addons.mozilla.org/firefox/user/something/'
+  - http://getpersonas.com/a_c/persona/456: 'https://addons.mozilla.org/persona/456'
+  - http://www.getpersonas.com/persona/45: 'https://addons.mozilla.org/persona/45'
+  - http://getpersonas.com/gallery/All/Movers: 'https://addons.mozilla.org/firefox/themes/?sort=up-and-coming'
+  - http://www.getpersonas.com/12d-a1/gallery/All/Movers: 'https://addons.mozilla.org/firefox/themes/?sort=up-and-coming'
+  - http://getpersonas.com/12_-a1/gallery/All/Recent: 'https://addons.mozilla.org/firefox/themes/?sort=created'
+  - http://www.getpersonas.com/gallery/All/Recent: 'https://addons.mozilla.org/firefox/themes/?sort=created'
+  - http://getpersonas.com/A_C/gallery/All/Popular: 'https://addons.mozilla.org/firefox/themes/?sort=popular'
+  - http://www.getpersonas.com/gallery/All/Popular: 'https://addons.mozilla.org/firefox/themes/?sort=popular'
+  - http://getpersonas.com/: 'https://addons.mozilla.org/themes/'
+  - http://www.getpersonas.com/not/a/real/path: 'https://addons.mozilla.org/themes/'
+
 - dsts:
   - if: '$query_string ~ "^hl=(?<hl>[^&]+)&url=(?<url>[^&]+)"'
     ^/$: 'www.stopbadware.org/firefox?hl=$hl&url=$url?'

--- a/refractr/schema.yml
+++ b/refractr/schema.yml
@@ -72,7 +72,7 @@ defs:
     title: dst-url
     type: string
     # single '$' added to file matcher to allow nginx exprs: $lang $request_uri
-    pattern: '^(?!https?:\/\/)([A-z0-9]+([A-z0-9\.\-]+)\/)([A-z0-9\-_]+\/)*([A-z0-9$\/\.\-_:]+)?(\?[A-z0-9$\.\-:=]+(&[A-z0-9$\.\-:=]+)*)?(#[A-z0-9\-_]+)?\??$' # added optional '?' for nginx rewrite
+    pattern: '^(?!https?:\/\/)([A-z0-9]+([A-z0-9\.\-$]+)\/)([A-z0-9\-_]+\/)*([A-z0-9$\/\.\-_:]+)?(\?[A-z0-9$\.\-:=]+(&[A-z0-9$\.\-:=]+)*)?(#[A-z0-9\-_]+)?\??$' # added optional '?' for nginx rewrite
   nginx-url:
     default: ''
     title: nginx-url


### PR DESCRIPTION
## Refractr PR Checklist

JIRA ticket: https://mozilla-hub.atlassian.net/browse/SE-2412

Just pushing this work up in case useful & to clear my local git for refractr. It was the way I found last week to add the personas.com regex matching paths redirect to refractr without changing refractr python classes (does require updating the refractr schema though). Happy to pair on reviewing it, again, if useful to have.

When creating a PR for Refractr, confirm you've done the following steps for smooth CI and CD experiences:
- [x] Is this the right place for your redirect (e.g. developer.mozilla.com/* redirects should be managed by MDN; other examples here as known)?
- [x] Have you updated the relevant YAML in the PR?
- [x] Have you checked the relevant YAML for any possible dupes regarding your domain?
- [x] Have you checked if there are any TLS cert concerns - e.g. if the domain being redirected already exists, and it is being changed to point at Refractr, is a temporary TLS 'outage' while waiting for Lets Encrypt certification via HTTP challenge okay? If not, [have you followed these steps for using DNS challenges with our cert-manager setup](https://mana.mozilla.org/wiki/display/SRE/Refractr+-+How+To+-+DNS+Challenges)?
- [x] If desired, have you generated the Nginx manually to confirm addition works as expected? 
- [x] If desired, are you able to connect to EKS (cluster itse-apps-prod-1, namespace fluxcd) to more closely monitor the deploys?

After PR merge, next steps include:
- [ ] If going straight from main merge & Stage deploy to a release & production deploy, create the relevant GitHub release with an incremented version / tag applied.
- [ ] Confirm you are ready and able to perform the requested DNS creation or change post-deploy? 
