### PR TITLE
Add missing redirect for https://bugzil.la/.

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -810,13 +810,17 @@ refracts:
 
 # bug SE-2241
 - dsts:
-  - if: '$request_uri'
+  - if: '$request_uri ~ ^/(\d+)$'
     ^/(\d+)$: bugzilla.mozilla.org/show_bug.cgi?id=$1
-  - ^/form(.+)$: bugzilla.mozilla.org/form$1
-  - ^/(.+)$: bugzilla.mozilla.org/buglist.cgi?quicksearch=$1
+  - if: '$request_uri ~ ^/form(.+)$'
+    ^/form(.+)$: bugzilla.mozilla.org/form$1
+  - if: '$request_uri ~ ^/(.+)'
+    ^/(.+)$: bugzilla.mozilla.org/buglist.cgi?quicksearch=$1
+  - redirect: bugzilla.mozilla.org/
   srcs:
   - bugzil.la
   tests:
+  - https://bugzil.la/: https://bugzilla.mozilla.org/
   - https://bugzil.la/123456: https://bugzilla.mozilla.org/show_bug.cgi?id=123456
   - https://bugzil.la/form.foo: https://bugzilla.mozilla.org/form.foo
   - https://bugzil.la/glonk: https://bugzilla.mozilla.org/buglist.cgi?quicksearch=glonk


### PR DESCRIPTION
This adds the redirect for / that was missing in #195. Unfortuantely, simply adding the redirect broke one of the other redirects, for reasons I can't explain. I changed the other redirects to the form we use for getpersonas.com, and now it seems to be working.

## Refractr PR Checklist

JIRA ticket: https://mozilla-hub.atlassian.net/browse/SE-2241

When creating a PR for Refractr, confirm you've done the following steps for smooth CI and CD experiences:
- [x] Is this the right place for your redirect (e.g. developer.mozilla.com/* redirects should be managed by MDN; other examples here as known)?
- [x] Have you updated the relevant YAML in the PR?
- [x] Have you checked the relevant YAML for any possible dupes regarding your domain?
- [x] Have you checked if there are any TLS cert concerns - e.g. if the domain being redirected already exists, and it is being changed to point at Refractr, is a temporary TLS 'outage' while waiting for Lets Encrypt certification via HTTP challenge okay? If not, [have you followed these steps for using DNS challenges with our cert-manager setup](https://mana.mozilla.org/wiki/display/SRE/Refractr+-+How+To+-+DNS+Challenges)?
- [x] If desired, have you generated the Nginx manually to confirm addition works as expected? 
- [ ] If desired, are you able to connect to EKS (cluster itse-apps-prod-1, namespace fluxcd) to more closely monitor the deploys?

After PR merge, next steps include:
- [ ] If going straight from main merge & Stage deploy to a release & production deploy, create the relevant GitHub release with an incremented version / tag applied.
- [ ] Confirm you are ready and able to perform the requested DNS creation or change post-deploy? 
