### PR TITLE
Remove trailing slashes from four Wikimo redirects [SE-2712]

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -189,7 +189,7 @@ refracts:
 - zombiekeys.quickfolders.org/: zombiekeys.mozdev.org
 - quickfolders.org/: quickfolders.mozdev.org
 - github.com/eyalroz/bidimailui/: bidiui.mozdev.org
-- wiki.mozilla.org/Consulting/: consultants.mozdev.org
+- wiki.mozilla.org/Consulting: consultants.mozdev.org
 - www.amadzone.org/mozilla-archive-format/: maf.mozdev.org
 - smarttemplates.quickfolders.org/: smarttemplate4.mozdev.org
 - quickpasswords.quickfolders.org/: quickpasswords.mozdev.org
@@ -312,7 +312,7 @@ refracts:
 - wiki.mozilla.org/: wiki.mozilla.com
 
   # bug 1290260
-- wiki.mozilla.org/DeveloperServices/HistoricalVCS/: git.mozilla.org
+- wiki.mozilla.org/DeveloperServices/HistoricalVCS: git.mozilla.org
   status: 302
 
   # bug 510914
@@ -320,10 +320,10 @@ refracts:
 - m.wiki.mozilla.org/Main_Page/: library.mozilla.org
 
   # bug 713065
-- wiki.mozilla.org/MarketingGuide/: guides.mozilla.org
+- wiki.mozilla.org/MarketingGuide: guides.mozilla.org
 
   # bug 804895
-- wiki.mozilla.org/Platform/AreWeFunYet/:
+- wiki.mozilla.org/Platform/AreWeFunYet:
   - arewefunyet.com
   - www.arewefunyet.com
 


### PR DESCRIPTION
## Refractr PR Checklist

JIRA ticket: [SE-2712](https://mozilla-hub.atlassian.net/browse/SE-2712)

When creating a PR for Refractr, confirm you've done the following steps for smooth CI and CD experiences:
- [x] Is this the right place for your redirect (e.g. developer.mozilla.com/* redirects should be managed by MDN; other examples here as known)?
- [x] Have you updated the relevant YAML in the PR?
- [ ] Have you checked the relevant YAML for any possible dupes regarding your domain?
- [x] Have you checked if there are any TLS cert concerns - e.g. if the domain being redirected already exists, and it is being changed to point at Refractr, is a temporary TLS 'outage' while waiting for Lets Encrypt certification via HTTP challenge okay? If not, [have you followed these steps for using DNS challenges with our cert-manager setup](https://mana.mozilla.org/wiki/display/SRE/Refractr+-+How+To+-+DNS+Challenges)?
- [x] If desired, have you generated the Nginx manually to confirm addition works as expected? 
- [x] If desired, are you able to connect to EKS (cluster itse-apps-prod-1, namespace fluxcd) to more closely monitor the deploys?

After PR merge, next steps include:
- [ ] If going straight from main merge & Stage deploy to a release & production deploy, create the relevant GitHub release with an incremented version / tag applied.
- [x] Confirm you are ready and able to perform the requested DNS creation or change post-deploy? 
