### PR TITLE
redirect *.add-ons.m.o & *.add-ons.m.c to addons.m.o

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -16,7 +16,7 @@ refracts:
   - activations.mozilla.com
   - activations.mozilla.org
 
-  # bug 503731, 528747, 537144, SE-1683
+  # bug 503731, 528747, 537144, SE-1683, SE-2688
 - addons.mozilla.org/:
   - extensions.mozilla.org
   - themes.mozilla.org
@@ -26,6 +26,10 @@ refracts:
   - firefoxaddons.com
   - www.firefoxaddons.com
   - addons.mozilla.com
+  - add-ons.mozilla.com
+  - add-ons.mozilla.org
+  - '*.add-ons.mozilla.com'
+  - '*.add-ons.mozilla.org'
 
   # bug 1342698
   # NOTE: changed from http->https after verifying


### PR DESCRIPTION
## Refractr PR Checklist

JIRA ticket: https://mozilla-hub.atlassian.net/browse/SE-2688

Wasn't certain if wildcard subdomain would owrk without the complex refract structure, but local testing seems to indicate it does. Hope to also test in production before flipping the DNS.

When creating a PR for Refractr, confirm you've done the following steps for smooth CI and CD experiences:
- [x] Is this the right place for your redirect (e.g. developer.mozilla.com/* redirects should be managed by MDN; other examples here as known)?
- [x] Have you updated the relevant YAML in the PR?
- [x] Have you checked the relevant YAML for any possible dupes regarding your domain?
- [x] Have you checked if there are any TLS cert concerns - e.g. if the domain being redirected already exists, and it is being changed to point at Refractr, is a temporary TLS 'outage' while waiting for Lets Encrypt certification via HTTP challenge okay? If not, [have you followed these steps for using DNS challenges with our cert-manager setup](https://mana.mozilla.org/wiki/display/SRE/Refractr+-+How+To+-+DNS+Challenges)?
- [x] If desired, have you generated the Nginx manually to confirm addition works as expected? 
- [x] If desired, are you able to connect to EKS (cluster itse-apps-prod-1, namespace fluxcd) to more closely monitor the deploys?

After PR merge, next steps include:
- [x] If going straight from main merge & Stage deploy to a release & production deploy, create the relevant GitHub release with an incremented version / tag applied.
- [x] Confirm you are ready and able to perform the requested DNS creation or change post-deploy? 
