### PR TITLE
Create path bad default

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -831,3 +831,13 @@ refracts:
   status: 302
 - www.mozilla.org/: status.mozilla.org
   status: 302
+
+- dsts:
+  - if: '$request_uri ~ "(?i)^/universityambassadors/?$"'
+    ^: 'campus.mozilla.community/?redirect_source=firefox-com'
+  preserve-path: false
+  srcs:
+  - www.firefox.com
+  tests:
+  - http://www.firefox.com/universityambassadors: 'https://campus.mozilla.community/?redirect_source=firefox-com'
+  - http://www.firefox.com/UniversityAmbassadors/: 'https://campus.mozilla.community/?redirect_source=firefox-com'

--- a/refractr/complex.py
+++ b/refractr/complex.py
@@ -74,7 +74,7 @@ class ComplexRefract(BaseRefract):
         rewrite = KeyMultiValueOption(
             'rewrite', [
                 match,
-                create_target(target),
+                create_target(target, self.preserve_path),
                 status_to_word(status or self.status),
             ]
         )


### PR DESCRIPTION
Jira: came up in context of https://mozilla-hub.atlassian.net/browse/SE-2448

What this PR does:
- fixes one of the ComplexRefract Python classes to pass the `preserve_path` class attribute to create_target, so the end user can use the `preserve-path` key in the refractr yaml specification to control this property.
- adds 1 example redirect that uses this `preserve-path` with a rewrite in a ComplexRefract, without doing any other setup for this redirect to go live in production