### PR TITLE
fix old mozillians/u/xyz URLs [SE-1960]

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -236,11 +236,29 @@ refracts:
 
 - mozilla-services.readthedocs.io/en/latest/: docs.services.mozilla.com
 
-  # Jira SE-1354
-- people.mozilla.org/:
+# Jira SE-1354
+- dsts:
+  # u->p rewrite [SE-1960]
+  - if: '$request_uri ~ ^/u/(.+)/*$'
+    ^/u/(.+)/*$: people.mozilla.org/p/$1
+  # no rewrite
+  - if: '$request_uri ~ ^/(.+)$'
+    ^/(.+)$: people.mozilla.org/$1
+  # fallthrough
+  - redirect: people.mozilla.org/
+  srcs:
   - mozillians.org
   # bug 1617378
   - www.mozillians.org
+  tests:
+  # u->p rewrite
+  - https://mozillians.org/u/abcdefg/: https://people.mozilla.org/p/abcdefg
+  - https://www.mozillians.org/u/abcdefg: https://people.mozilla.org/p/abcdefg
+  # no rewrite
+  - https://mozillians.org/x/abcdefg: https://people.mozilla.org/x/abcdefg
+  # fallthrough
+  - https://www.mozillians.org/: https://people.mozilla.org/
+  - https://mozillians.org/: https://people.mozilla.org/
 
   # bug 1459170
 - perf-html.io/: cleopatra.io


### PR DESCRIPTION
Old Mozillians.org links to users have apparently been broken for the past year or three, so this PR attempts to repair that. This somewhat complicates the redirect definition, for review/testing purposes. Assuming the tests are written correctly *and* pass, this could safely be deployed at any time.

## Refractr PR Checklist

JIRA ticket: [link to relevant JIRA or other system ticket]

When creating a PR for Refractr, confirm you've done the following steps for smooth CI and CD experiences:
- [x] Is this the right place for your redirect (e.g. developer.mozilla.com/* redirects should be managed by MDN; other examples here as known)?
- [x] Have you updated the relevant YAML in the PR?
- [x] Have you checked the relevant YAML for any possible dupes regarding your domain?
- [x] Have you checked if there are any TLS cert concerns - e.g. if the domain being redirected already exists, and it is being changed to point at Refractr, is a temporary TLS 'outage' while waiting for Lets Encrypt certification via HTTP challenge okay? If not, [have you followed these steps for using DNS challenges with our cert-manager setup](https://mana.mozilla.org/wiki/display/SRE/Refractr+-+How+To+-+DNS+Challenges)?
- [ ] If desired, have you generated the Nginx manually to confirm addition works as expected? 
- [x] If desired, are you able to connect to EKS (cluster itse-apps-prod-1, namespace fluxcd) to more closely monitor the deploys?

After PR merge, next steps include:
- [ ] If going straight from main merge & Stage deploy to a release & production deploy, create the relevant GitHub release with an incremented version / tag applied.
- [ ] Confirm you are ready and able to perform the requested DNS creation or change post-deploy? 
