### PR TITLE
Removing relay and vpn status pages from refractr

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -825,10 +825,6 @@ refracts:
   - https://bugzil.la/glonk: https://bugzilla.mozilla.org/buglist.cgi?quicksearch=glonk
 
 # https://mozilla-hub.atlassian.net/browse/SVCSE-140
-- www.mozilla.org/: status.relay.firefox.com
-  status: 302
-- www.mozilla.org/: status.vpn.mozilla.org
-  status: 302
 - www.mozilla.org/: status.mozilla.org
   status: 302
 


### PR DESCRIPTION
## Refractr PR Checklist

JIRA ticket: [SVCSE-152](https://mozilla-hub.atlassian.net/browse/SVCSE-152)

For now we will keep `status.mozilla.org` in refractr. VPN and Relay have already had DNS updated to point at the new status pages.

When creating a PR for Refractr, confirm you've done the following steps for smooth CI and CD experiences:
- [x] Is this the right place for your redirect (e.g. developer.mozilla.com/* redirects should be managed by MDN; other examples here as known)?
- [x] Have you updated the relevant YAML in the PR?
- [x] Have you checked the relevant YAML for any possible dupes regarding your domain?
- [x] Have you checked if there are any TLS cert concerns - e.g. if the domain being redirected already exists, and it is being changed to point at Refractr, is a temporary TLS 'outage' while waiting for Lets Encrypt certification via HTTP challenge okay? If not, [have you followed these steps for using DNS challenges with our cert-manager setup](https://mana.mozilla.org/wiki/display/SRE/Refractr+-+How+To+-+DNS+Challenges)?
- [x] If desired, have you generated the Nginx manually to confirm addition works as expected? 
- [x] If desired, are you able to connect to EKS (cluster itse-apps-prod-1, namespace fluxcd) to more closely monitor the deploys?

After PR merge, next steps include:
- [x] If going straight from main merge & Stage deploy to a release & production deploy, create the relevant GitHub release with an incremented version / tag applied.
- [x] Confirm you are ready and able to perform the requested DNS creation or change post-deploy? 