### PR TITLE
add mozillafoundation.org, www redirects [SE-2915]

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -142,12 +142,18 @@ refracts:
 - community.mozilla.org/en/groups/tech-speakers/:
   - techspeakers.mozilla.org
 
-  # bug 1195576
-  # FIXME: this commented out redirect is incorrect, added correct one below
-  #- mozillafoundation.org:
+# SE-2915 (specific campaign)
+- foundation.mozilla.org/youtube/regretsreporter/:
+  - mozillafoundation.org/regretsreporter
+  - www.mozillafoundation.org/regretsreporter
+
 - foundation.mozilla.org/:
+  # bug 1195576
   - mozillafoundation.com
   - mozillafoundation.net
+  # SE-2915 (catchall)
+  - mozillafoundation.org
+  - www.mozillafoundation.org
   # SE-1627
   - surveillance.mozilla.org
 


### PR DESCRIPTION
Note: Some DNS changes may be useful to pursue for this domain, as it's currently hosted inside Route53 inside an old AWS account, in addition to the usual root-A / www-CNAME.

## Refractr PR Checklist

JIRA ticket: https://mozilla-hub.atlassian.net/browse/SE-2915

When creating a PR for Refractr, confirm you've done the following steps for smooth CI and CD experiences:
- [x] Is this the right place for your redirect (e.g. developer.mozilla.com/* redirects should be managed by MDN; other examples here as known)?
- [x] Have you updated the relevant YAML in the PR?
- [x] Have you checked the relevant YAML for any possible dupes regarding your domain?
- [ ] Have you checked if there are any TLS cert concerns - e.g. if the domain being redirected already exists, and it is being changed to point at Refractr, is a temporary TLS 'outage' while waiting for Lets Encrypt certification via HTTP challenge okay? If not, [have you followed these steps for using DNS challenges with our cert-manager setup](https://mana.mozilla.org/wiki/display/SRE/Refractr+-+How+To+-+DNS+Challenges)?
- [ ] If desired, have you generated the Nginx manually to confirm addition works as expected? 
- [x] If desired, are you able to connect to EKS (cluster itse-apps-prod-1, namespace fluxcd) to more closely monitor the deploys?

After PR merge, next steps include:
- [ ] If going straight from main merge & Stage deploy to a release & production deploy, create the relevant GitHub release with an incremented version / tag applied.
- [ ] Confirm you are ready and able to perform the requested DNS creation or change post-deploy? 
