### PR TITLE
redirect status.services.mozilla.com to www.mozilla.org

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -453,6 +453,9 @@ refracts:
 
 - www.mozilla.org/: send.firefox.com
 
+  # DSRE-493
+- www.mozilla.org/: status.services.mozilla.com
+
   # bug 537925
   # NOTE: simplified this after testing, this simple redirect is all that is needed
 - www.mozilla.org/contribute/: contribute.mozilla.org


### PR DESCRIPTION
## Refractr PR Checklist

JIRA ticket: https://mozilla-hub.atlassian.net/browse/DSRE-493

When creating a PR for Refractr, confirm you've done the following steps for smooth CI and CD experiences:
- [x] Is this the right place for your redirect (e.g. developer.mozilla.com/* redirects should be managed by MDN; other examples here as known)?
- [x] Have you updated the relevant YAML in the PR?
- [x] Have you checked the relevant YAML for any possible dupes regarding your domain?
- [x] Have you checked if there are any TLS cert concerns - e.g. if the domain being redirected already exists, and it is being changed to point at Refractr, is a temporary TLS 'outage' while waiting for Lets Encrypt certification via HTTP challenge okay? If not, [have you followed these steps for using DNS challenges with our cert-manager setup](https://mana.mozilla.org/wiki/display/SRE/Refractr+-+How+To+-+DNS+Challenges)?
- [x] If desired, have you generated the Nginx manually to confirm addition works as expected? 
- [x] If desired, are you able to connect to EKS (cluster itse-apps-prod-1, namespace fluxcd) to more closely monitor the deploys?

After PR merge, next steps include:
- [x] If going straight from main merge & Stage deploy to a release & production deploy, create the relevant GitHub release with an incremented version / tag applied.
- [x] Confirm you are ready and able to perform the requested DNS creation or change post-deploy? 
