### PR TITLE
Add redirects for firefox.com/turningred and turningred.firefox.com

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -920,6 +920,12 @@ refracts:
       ^: 'www.mozilla.org/firefox/unfck/?redirect_source=firefox-com&utm_medium=audio&utm_source=prosieben&utm_campaign=unfck&utm_content=podcast'
     - if: '$request_uri ~ "(?i)^/(unfu?ck|love|rendonslenetplusnet)/?$"' # issues #19, #18, #15, #13, and #27, and Jira SE-1256
       ^: 'www.mozilla.org/firefox/unfck/?redirect_source=firefox-com&utm_medium=referral&utm_source=firefox.com&utm_campaign=unfck'
+    # in the case of no query string add the default args
+    - if: '$request_uri ~ "(?i)^/(turningred|truecolors)/?$"' # SE-3052
+      ^: 'truecolors.firefox.com/?utm_campaign=firefox-disney-us&utm_medium=web&utm_source=redirect&utm_content=firefox.com-turningred'
+    # request query string is automatically preserved
+    - if: '$request_uri ~ "(?i)^/(turningred|truecolors)/?\?"' # SE-3052
+      ^: 'truecolors.firefox.com/'
     - redirect: 'www.mozilla.org/firefox/new/?redirect_source=firefox-com' #fallback redirect, bug 896570, bug 1427843
   status: 302
   headers:
@@ -971,4 +977,23 @@ refracts:
   - http://www.firefox.com/love: 'https://www.mozilla.org/firefox/unfck/?redirect_source=firefox-com&utm_medium=referral&utm_source=firefox.com&utm_campaign=unfck'
   - http://www.firefox.com/rendonslenetplusnet: 'https://www.mozilla.org/firefox/unfck/?redirect_source=firefox-com&utm_medium=referral&utm_source=firefox.com&utm_campaign=unfck'
   - http://www.firefox.com/foo/bar: 'https://www.mozilla.org/firefox/new/?redirect_source=firefox-com'
+  - http://www.firefox.com/turningred/: 'https://truecolors.firefox.com/?utm_campaign=firefox-disney-us&utm_medium=web&utm_source=redirect&utm_content=firefox.com-turningred'
+  - http://www.firefox.com/turningred/?utm_source=dude: 'https://truecolors.firefox.com/?utm_source=dude'
+  - http://www.firefox.com/truecolors/: 'https://truecolors.firefox.com/?utm_campaign=firefox-disney-us&utm_medium=web&utm_source=redirect&utm_content=firefox.com-turningred'
+  - http://www.firefox.com/truecolors/?utm_source=dude: 'https://truecolors.firefox.com/?utm_source=dude'
 
+# SE-3052
+- dsts:
+    # if incoming query_string preserve it
+    - if: '$args != ""'
+      ^: 'truecolors.firefox.com$uri'
+    - redirect: 'truecolors.firefox.com$uri?utm_campaign=firefox-disney-us&utm_medium=web&utm_source=redirect&utm_content=turningred.firefox.com'
+  status: 302
+  preserve-path: false
+  srcs:
+  - turningred.firefox.com
+  tests:
+  - http://turningred.firefox.com/colorways: 'https://truecolors.firefox.com/colorways?utm_campaign=firefox-disney-us&utm_medium=web&utm_source=redirect&utm_content=turningred.firefox.com'
+  - http://turningred.firefox.com/colorways?utm_source=dude: 'https://truecolors.firefox.com/colorways?utm_source=dude'
+  - http://turningred.firefox.com/: 'https://truecolors.firefox.com/?utm_campaign=firefox-disney-us&utm_medium=web&utm_source=redirect&utm_content=turningred.firefox.com'
+  - http://turningred.firefox.com/?utm_source=dude: 'https://truecolors.firefox.com/?utm_source=dude'

--- a/refractr/schema.yml
+++ b/refractr/schema.yml
@@ -72,7 +72,7 @@ defs:
     title: dst-url
     type: string
     # single '$' added to file matcher to allow nginx exprs: $lang $request_uri
-    pattern: '^(?!https?:\/\/)([A-z0-9]+([A-z0-9\.\-$]+)\/)([A-z0-9\-_]+\/)*([A-z0-9$\/\.\-_:]+)?(\?[A-z0-9$\.\-:=]+(&[A-z0-9$\.\-:=]+)*)?(#[A-z0-9\-_]+)?\??$' # added optional '?' for nginx rewrite
+    pattern: '^(?!https?:\/\/)([A-z0-9]+([A-z0-9\.\-$]+)\/?)([A-z0-9\-_]+\/)*([A-z0-9$\/\.\-_:]+)?(\?[A-z0-9$\.\-:=]+(&[A-z0-9$\.\-:=]+)*)?(#[A-z0-9\-_]+)?\??$' # added optional '?' for nginx rewrite
   nginx-url:
     default: ''
     title: nginx-url


### PR DESCRIPTION
The turningred.firefox.com domain will need to be created and pointed to Refractr.

Fix [SE-3052](https://mozilla-hub.atlassian.net/browse/SE-3052)