### PR TITLE
feat(ftv.cdn) Redirect a few endpoints to youtube, 404 the rest

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -1000,3 +1000,17 @@ refracts:
   - http://turningred.firefox.com/: 'https://truecolors.firefox.com/?utm_campaign=firefox-disney-us&utm_medium=web&utm_source=redirect&utm_content=turningred.firefox.com'
   - http://turningred.firefox.com/?utm_source=dude: 'https://truecolors.firefox.com/?utm_source=dude'
   - http://truecolours.firefox.com/: 'https://truecolors.firefox.com/?utm_campaign=firefox-disney-us&utm_medium=web&utm_source=redirect&utm_content=turningred.firefox.com'
+
+# SE-3060
+- dsts:
+  - if: '$request_uri ~ ^/ytht(.*)$'
+    ^: 'm.youtube.com/'
+  - if: '$request_uri ~ ^/ytfc(.*)$'
+    ^: 'm.youtube.com/'
+  preserve-path: false
+  srcs:
+  - ftv.cdn.mozilla.net
+  tests:
+  - http://ftv.cdn.mozilla.net/ytht: https://m.youtube.com/
+  - http://ftv.cdn.mozilla.net/ytfc: https://m.youtube.com/
+  - http://ftv.cdn.mozilla.net/ytfcfoo: https://m.youtube.com/


### PR DESCRIPTION
## Refractr PR Checklist

[SE-3060](https://mozilla-hub.atlassian.net/browse/SE-3060)

This seems to behave correctly based on the request in the ticket. We only care about a couple endpoints, everything else can 404. There doesn't seem to be a good way to write a test about the default behavior but it does seem to work as requested.

Testing locally:
```bash
$ curl -H 'Host: ftv.cdn.mozilla.net' localhost
<html>
<head><title>404 Not Found</title></head>
<body>
<center><h1>404 Not Found</h1></center>
<hr><center>nginx</center>
</body>
</html>

$ curl -I -H 'Host: ftv.cdn.mozilla.net' localhost/ytht
HTTP/1.1 301 Moved Permanently
Server: nginx
Date: Tue, 29 Mar 2022 18:53:54 GMT
Content-Type: text/html
Content-Length: 162
Connection: keep-alive
Location: https://m.youtube.com/
Strict-Transport-Security: max-age=60; includeSubDomains

$ curl -I -H 'Host: ftv.cdn.mozilla.net' localhost/ythtfoo
HTTP/1.1 301 Moved Permanently
Server: nginx
Date: Tue, 29 Mar 2022 18:53:56 GMT
Content-Type: text/html
Content-Length: 162
Connection: keep-alive
Location: https://m.youtube.com/
Strict-Transport-Security: max-age=60; includeSubDomains

$ curl -I -H 'Host: ftv.cdn.mozilla.net' localhost/ytfc
HTTP/1.1 301 Moved Permanently
Server: nginx
Date: Tue, 29 Mar 2022 18:54:04 GMT
Content-Type: text/html
Content-Length: 162
Connection: keep-alive
Location: https://m.youtube.com/
Strict-Transport-Security: max-age=60; includeSubDomains

$ curl -I -H 'Host: ftv.cdn.mozilla.net' localhost/ytfcboo
HTTP/1.1 301 Moved Permanently
Server: nginx
Date: Tue, 29 Mar 2022 18:54:06 GMT
Content-Type: text/html
Content-Length: 162
Connection: keep-alive
Location: https://m.youtube.com/
Strict-Transport-Security: max-age=60; includeSubDomains

```