### PR TITLE
chore(redirect): tekcopteg.com to www.tekcopteg.com

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -1027,3 +1027,7 @@ refracts:
   tests:
     - http://www.webxr.today/: "https://support.mozilla.org/en-US/kb/end-support-firefox-reality"
     - http://webxr.today/: "https://support.mozilla.org/en-US/kb/end-support-firefox-reality"
+
+# SE-3133
+- www.tekcopteg.com: tekcopteg.com
+


### PR DESCRIPTION
We want to point the root at a cloudfront distribution which we cannot do because the root is in infoblox. This is the same behavior as mozilla.org. Point the A record at refractr point a www cname at cloudfront