### PR TITLE
SRE-3342

### DIFF
--- a/SRE_INFO.md
+++ b/SRE_INFO.md
@@ -1,5 +1,5 @@
 # SRE Info
-This is the SRE_INFO.md file which should be found in the root of any source code that is administered by the Mozilla Web IT SRE team. We are available on #it-web-sre on slack.
+This is the SRE_INFO.md file which should be found in the root of any source code that is administered by the Mozilla SRE Green team. We are available on #sre on slack.
 
 ## Overview
 Refractr, the application, involves the following parts:
@@ -11,7 +11,7 @@ Refractr, the application, involves the following parts:
 
 ## Doit (dodo.py)
 
-Doit is a Python framework meant to replace Makefiles and similar tools. The following are the Doit tasks we have defined and fun as part of CI for Refractr:
+Doit is a Python framework meant to replace Makefiles and similar tools. The following are the Doit tasks we have defined and run as part of CI for Refractr:
 
 1. doit schema (validate dev-refractr.yaml or prod-refractr.yaml - depending on branch - against refractr/schema.yml
 1. doit nginx (generate nginx configurations from dev|prod-refractr.yaml)

--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -1061,6 +1061,14 @@ refracts:
 # SE-3315
 - developer.mozilla.org/en-US/docs/MDN: mdn-contributor-docs.mozilla.org
 
+# SE-3342
+- dsts: 
+    - redirect: mozilla-hub.atlassian.net/
+  srcs: mana.mozilla.org
+  status: 301
+  tests:
+  - https://mana.mozilla.org/wiki/display/PR/Career+Development+Resources: https://mozilla-hub.atlassian.net/wiki/display/PR/Career+Development+Resources
+
 # 404 Hosts
 - nginx: |
      server {

--- a/refractr/schema.yml
+++ b/refractr/schema.yml
@@ -49,7 +49,7 @@ defs:
     default: ''
     title: test-url
     type: string
-    pattern: '^(https?:\/\/)([A-z0-9]+([A-z0-9\.\-]+)\/)([A-z0-9\-_]+\/)*([A-z0-9$\/\.\-_:]+)?(\?[A-z0-9\.\-:=]+(&[A-z0-9\.\-:=]+)*)?(#[A-z0-9\-_]+)?$'
+    pattern: '^(https?:\/\/)([A-z0-9]+([A-z0-9\.\-]+)\/)([A-z0-9\-_]+\/)*([A-z0-9$\/\.\-_+:]+)?(\?[A-z0-9\.\-:=]+(&[A-z0-9\.\-:=]+)*)?(#[A-z0-9\-_]+)?$'
   test-urls:
     default: []
     title: test-urls
@@ -138,7 +138,7 @@ defs:
     maxProperties: 2
     additionalProperties: false
     patternProperties:
-      '^(https?:\/\/)([A-z0-9]+([A-z0-9\.\-]+)\/)([A-z0-9\-_]+\/)*([A-z0-9$\/\.\-_:]+)?(\?[A-z0-9$\.\-:=]+(&[A-z0-9$\.\-:=]+)*)?(#[A-z0-9\-_]+)?$':
+      '^(https?:\/\/)([A-z0-9]+([A-z0-9\.\-]+)\/)([A-z0-9\-_]+\/)*([A-z0-9$\/\.\-_:+]+)?(\?[A-z0-9$\.\-:=]+(&[A-z0-9$\.\-:=]+)*)?(#[A-z0-9\-_]+)?$':
         $ref: '#/defs/test-url'
     properties:
       status:


### PR DESCRIPTION
redirect mana.mozilla.org -> mozilla-hub.atlassian.net
adding regex match to refractr/schema.yml to validate urls that include '+' characters like many used in confluence

## Refractr PR Checklist

JIRA ticket: https://mozilla-hub.atlassian.net/browse/SE-3342

When creating a PR for Refractr, confirm you've done the following steps for smooth CI and CD experiences:
- [x] Is this the right place for your redirect (e.g. developer.mozilla.com/* redirects should be managed by MDN; other examples here as known)?
- [x] Have you updated the relevant YAML in the PR?
- [x] Have you checked the relevant YAML for any possible dupes regarding your domain?
- [x] Have you checked if there are any TLS cert concerns - e.g. if the domain being redirected already exists, and it is being changed to point at Refractr, is a temporary TLS 'outage' while waiting for Lets Encrypt certification via HTTP challenge okay? If not, [have you followed these steps for using DNS challenges with our cert-manager setup](https://mana.mozilla.org/wiki/display/SRE/Refractr+-+How+To+-+DNS+Challenges)?
- [x] If desired, have you generated the Nginx manually to confirm addition works as expected? 
- [x] If desired, are you able to connect to EKS (cluster itse-apps-prod-1, namespace fluxcd) to more closely monitor the deploys?

After PR merge, next steps include:
- [x] If going straight from main merge & Stage deploy to a release & production deploy, create the relevant GitHub release with an incremented version / tag applied.
- [x] Confirm you are ready and able to perform the requested DNS creation or change post-deploy? 
