### PR TITLE
Add missioncontrol.telemetry.mozilla.org redirect

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -1073,6 +1073,9 @@ refracts:
 
 - mozilla-hub-sandbox-721.atlassian.net/: mana.allizom.org
 
+# DSRE-671
+- mozilla.cloud.looker.com/dashboards/918: missioncontrol.telemetry.mozilla.org
+
 # 404 Hosts
 - nginx: |
      server {


### PR DESCRIPTION
## Refractr PR Checklist

JIRA ticket: https://mozilla-hub.atlassian.net/browse/DSRE-671

When creating a PR for Refractr, confirm you've done the following steps for smooth CI and CD experiences:
- [X] Is this the right place for your redirect (e.g. developer.mozilla.com/* redirects should be managed by MDN; other examples here as known)?
- [X]  Have you updated the relevant YAML in the PR?
- [X] Have you checked the relevant YAML for any possible dupes regarding your domain?
- [X] Have you checked if there are any TLS cert concerns - e.g. if the domain being redirected already exists, and it is being changed to point at Refractr, is a temporary TLS 'outage' while waiting for Lets Encrypt certification via HTTP challenge okay? If not, [have you followed these steps for using DNS challenges with our cert-manager setup](https://mana.mozilla.org/wiki/display/SRE/Refractr+-+How+To+-+DNS+Challenges)?
- [ ] If desired, have you generated the Nginx manually to confirm addition works as expected? 
- [ ] If desired, are you able to connect to EKS (cluster itse-apps-prod-1, namespace fluxcd) to more closely monitor the deploys?

After PR merge, next steps include:
- [ ] If going straight from main merge & Stage deploy to a release & production deploy, create the relevant GitHub release with an incremented version / tag applied.
- [X] Confirm you are ready and able to perform the requested DNS creation or change post-deploy? 

I had just asked :gcox to delete DNS for this entirely yesterday but there was enough desire to have a redirect that we'd like one. Once this lands I will ask gcox to update DNS, but I'm not too familiar with the deployment process.