### PR TITLE
Added workaround for trailing '?'

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -1063,13 +1063,16 @@ refracts:
 
 # SE-3342
 - dsts: 
+  - if: $query_string ~ "pageId=109979676"
+    ^: mozilla-hub.atlassian.net/wiki/spaces/PR/pages/24451391/Time+Off+Vacation?
   - if: '$request_uri ~ ^/wiki/(.*)'
     ^: mozilla-hub.atlassian.net/
   - redirect: mozilla-hub.atlassian.net/wiki/
   srcs: mana.mozilla.org
   tests:
-    - http://mana.mozilla.org/wiki/display/PR/Career+Development+Resources: https://mozilla-hub.atlassian.net/wiki/display/PR/Career+Development+Resources
     - http://mana.mozilla.org/: https://mozilla-hub.atlassian.net/wiki/
+    - http://mana.mozilla.org/wiki/display/PR/Career+Development+Resources: https://mozilla-hub.atlassian.net/wiki/display/PR/Career+Development+Resources
+    - https://mana.mozilla.org/wiki/pages/viewpage.action?pageId=109979676: https://mozilla-hub.atlassian.net/wiki/spaces/PR/pages/24451391/Time+Off+Vacation
 
 - mozilla-hub-sandbox-721.atlassian.net/: mana.allizom.org
 

--- a/refractr/base.py
+++ b/refractr/base.py
@@ -20,6 +20,13 @@ def preserve(url):
 
 def create_target(dst, preserve_path=True):
     url = URL(dst).https
+    # urllib may return "a slightly different, but equivalent URL"
+    # which may remove a trailing '?' - the trailing '?' is used in the
+    # nginx confguration to indicate that query params should not be appended. 
+    # The trailing '?' is only present in nginx.conf, not the redireceted url
+    # (https://github.com/python/cpython/blob/main/Lib/urllib/parse.py#L483-L492)
+    if not url.endswith('?') and dst.endswith('?'):
+        url += '?'
     if preserve_path and URL(dst).path == '/':
         return preserve(url)
     return url

--- a/refractr/schema.yml
+++ b/refractr/schema.yml
@@ -72,7 +72,7 @@ defs:
     title: dst-url
     type: string
     # single '$' added to file matcher to allow nginx exprs: $lang $request_uri
-    pattern: '^(?!https?:\/\/)([A-z0-9]+([A-z0-9\.\-$]+)\/?)([A-z0-9\-_]+\/)*([A-z0-9$\/\.\-_:]+)?(\?[A-z0-9$\.\-:=]+(&[A-z0-9$\.\-:=]+)*)?(#[A-z0-9\-_]+)?\??$' # added optional '?' for nginx rewrite
+    pattern: '^(?!https?:\/\/)([A-z0-9]+([A-z0-9\.\-$]+)\/?)([A-z0-9\-_]+\/)*([A-z0-9$\/\.\-_:+]+)?(\?[A-z0-9$\.\-:=]+(&[A-z0-9$\.\-:=]+)*)?(#[A-z0-9\-_]+)?\??$' # added optional '?' for nginx rewrite
   nginx-url:
     default: ''
     title: nginx-url


### PR DESCRIPTION
adding refract for specific mana page linked from pto.m.o updated schema to accomodate dst urls that include '+'

## Refractr PR Checklist

JIRA ticket: [link to relevant JIRA or other system ticket]

When creating a PR for Refractr, confirm you've done the following steps for smooth CI and CD experiences:
- [x] Is this the right place for your redirect (e.g. developer.mozilla.com/* redirects should be managed by MDN; other examples here as known)?
- [x] Have you updated the relevant YAML in the PR?
- [x] Have you checked the relevant YAML for any possible dupes regarding your domain?
- [x] Have you checked if there are any TLS cert concerns - e.g. if the domain being redirected already exists, and it is being changed to point at Refractr, is a temporary TLS 'outage' while waiting for Lets Encrypt certification via HTTP challenge okay? If not, [have you followed these steps for using DNS challenges with our cert-manager setup](https://mana.mozilla.org/wiki/display/SRE/Refractr+-+How+To+-+DNS+Challenges)?
- [x] If desired, have you generated the Nginx manually to confirm addition works as expected? 
- [x] If desired, are you able to connect to EKS (cluster itse-apps-prod-1, namespace fluxcd) to more closely monitor the deploys?

After PR merge, next steps include:
- [x] If going straight from main merge & Stage deploy to a release & production deploy, create the relevant GitHub release with an incremented version / tag applied.
- [x] Confirm you are ready and able to perform the requested DNS creation or change post-deploy? 
