### PR TITLE
Remove utm_source as it is not cached by wpengine

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -1080,7 +1080,7 @@ refracts:
 - mozilla.cloud.looker.com/dashboards/918: missioncontrol.telemetry.mozilla.org
 
 # SE-3386
-- blog.mozilla.org/en/mozilla/pulse-joins-the-mozilla-family/?utm_source=getpulse.team:
+- blog.mozilla.org/en/mozilla/pulse-joins-the-mozilla-family/:
   - automaticstatus.com
   - commons.so
   - focustime.ai


### PR DESCRIPTION
WPENGINE (blog.m.o) does not cache utm_source. This is contributing to increased utilization.