### PR TITLE
chore(bedrock): Do not duplicate parameters

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -378,7 +378,7 @@ refracts:
       X-Backend-Server: TS
       Cache-Control: max-age=3600
     endpoint: www.mozilla.org
-  - ^/(.*): www.mozilla.org/
+  - ^/(.*): 'www.mozilla.org/$1'
   srcs: mozilla.org
   headers:
     X-Backend-Server: TS


### PR DESCRIPTION
This is a common problem in many of the refractr setups. We unintentionally duplicate request parameters.

Old generated configuration:
```bash
server {                                                                        
    server_name mozilla.org;                                                    
    add_header Strict-Transport-Security "max-age=60; includeSubDomains" always;
    add_header X-Backend-Server TS;                                             
    add_header Cache-Control max-age=3600;                                      
    location = /.well-known/matrix/client {                                     
        add_header Access-Control-Allow-Origin '*';                             
        add_header Access-Control-Allow-Methods 'GET, POST, PUT, DELETE, OPTIONS';
        add_header Access-Control-Allow-Headers 'X-Requested-With, Content-Type, Authorization'
        add_header X-Backend-Server TS;                                         
        add_header Cache-Control max-age=3600;                                  
        return 301 https://www.mozilla.org/.well-known/matrix/client;                          
    }                                                                                          
    location / {                                                                               
        rewrite ^/(.*) https://www.mozilla.org$request_uri permanent;                          
    }                                                                                          
}                                                                                              
```

Old behavior:
```bash
$ curl -is -H 'Host: mozilla.org' localhost/banana?this=that | grep -i location
Location: https://www.mozilla.org/banana?this=that?this=that
```

New generated configuration:
```bash
server {                                                                        
    server_name mozilla.org;                                                    
    add_header Strict-Transport-Security "max-age=60; includeSubDomains" always;
    add_header X-Backend-Server TS;                                             
    add_header Cache-Control max-age=3600;                                      
    location = /.well-known/matrix/client {                                     
        add_header Access-Control-Allow-Origin '*';                             
        add_header Access-Control-Allow-Methods 'GET, POST, PUT, DELETE, OPTIONS';
        add_header Access-Control-Allow-Headers 'X-Requested-With, Content-Type, Authorization'
        add_header X-Backend-Server TS;                                         
        add_header Cache-Control max-age=3600;                                  
        return 301 https://www.mozilla.org/.well-known/matrix/client;           
    }                                                                           
    location / {                                                                
        rewrite ^/(.*) https://www.mozilla.org/$1 permanent;                                   
    }                                                                                          
}                                                                                              
```

New behavior:
```bash
$ curl -is -H 'Host: mozilla.org' localhost/banana?this=that | grep -i location
Location: https://www.mozilla.org/banana?this=that
```