### PR TITLE
fixup: Add trailing slash to redirect

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -1116,7 +1116,7 @@ refracts:
 - hubs.mozilla.com/labs/: mixedreality.mozilla.org
 
 # OPST-277 Redirect mdn.mozillademos.org to mdn.dev
-- mdn.dev: mdn.mozillademos.org
+- mdn.dev/: mdn.mozillademos.org
 
 # SE-3426
 - acorn.firefox.com/: design.firefox.com


### PR DESCRIPTION
Forgot to add the trailing slash here.
