### PR TITLE
chore(perf-html): Force quoted header

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -294,12 +294,12 @@ refracts:
 - dsts:
   - url: /*
     headers:
-      Clear-Site-Data: "storage"
+      Clear-Site-Data: \"storage\"
     endpoint: profiler.firefox.com/
   - ^/(.*): profiler.firefox.com/
   srcs: perf-html.io
   headers:
-    Clear-Site-Data: "storage"
+    Clear-Site-Data: \"storage\"
   tests:
   - https://perf-html.io/: https://profiler.firefox.com/
 


### PR DESCRIPTION
## Refractr PR Checklist

This is kind of interesting! The regular quotes are put into the nginx config but are not sent to the client. In this particular header if the string isn't wrapped in a double quote it is [considered invalid](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data?utm_source=mozilla&utm_medium=devtools-netmonitor&utm_campaign=default).

This plops the escape into the nginx config:
```bash
add_header Clear-Site-Data \"storage\";
```

And I confirmed locally that the quote is returned via curl:
```bash
$ curl -i -L --header 'Host: perf-html.io' localhost
HTTP/1.1 301 Moved Permanently
Server: nginx
Date: Fri, 12 May 2023 14:48:34 GMT
Content-Type: text/html
Content-Length: 162
Connection: keep-alive
Location: https://profiler.firefox.com/
Strict-Transport-Security: max-age=60; includeSubDomains
Clear-Site-Data: "storage"
```