### PR TITLE
Fix help.getpocket.com redirect.

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -1199,8 +1199,8 @@ refracts:
 
 # SE-3598 - Pocket support migration to SUMO
 - dsts:
-  - if: '$uri ~ ^/article/(.*)$'
-    ^/(\d+)$: support.mozilla.org/kb/pocket/$1
+  - if: '$request_uri ~ ^/article/(.*)$'
+    ^/article/(.*$): support.mozilla.org/kb/pocket/$1
   - redirect: support.mozilla.org/products/pocket
   srcs:
   - help.getpocket.com


### PR DESCRIPTION
## Refractr PR Checklist

Fixup for #288.

JIRA ticket: [SE-3598](https://mozilla-hub.atlassian.net/browse/SE-3598)

When creating a PR for Refractr, confirm you've done the following steps for smooth CI and CD experiences:
- [x] Is this the right place for your redirect (e.g. developer.mozilla.com/* redirects should be managed by MDN; other examples here as known)?
- [x] Have you updated the relevant YAML in the PR?
- [x] Have you checked the relevant YAML for any possible dupes regarding your domain?
- [x] Have you checked if there are any TLS cert concerns - e.g. if the domain being redirected already exists, and it is being changed to point at Refractr, is a temporary TLS 'outage' while waiting for Lets Encrypt certification via HTTP challenge okay? If not, [have you followed these steps for using DNS challenges with our cert-manager setup](https://mana.mozilla.org/wiki/display/SRE/Refractr+-+How+To+-+DNS+Challenges)?
- [x] If desired, have you generated the Nginx manually to confirm addition works as expected? 
- [x] If desired, are you able to connect to EKS (cluster itse-apps-prod-1, namespace fluxcd) to more closely monitor the deploys?

After PR merge, next steps include:
- [ ] If going straight from main merge & Stage deploy to a release & production deploy, create the relevant GitHub release with an incremented version / tag applied.
- [ ] Confirm you are ready and able to perform the requested DNS creation or change post-deploy? 
