### PR TITLE
Fix up for rise25 redirect.

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -1214,5 +1214,5 @@ refracts:
   - https://help.getpocket.com/notarticle/fooo/bar: https://support.mozilla.org/products/pocket
 
 # SE-3620
-- https://blog.mozilla.org/en/mozilla/rise-25-winners/?source=web-redirect: rise25.mozilla.org
+- blog.mozilla.org/en/mozilla/rise-25-winners/?source=web-redirect: rise25.mozilla.org
   status: 302


### PR DESCRIPTION
Fix up for #290. Apparently, the redirect target must not include "https://".

For some reason, CI was successful for the PR and after merging to main, and only failed once I tagged a release. We should make sure the tests run on the PR branch as well; it would be really nice to catch this before merging the PR and tagging a release.