### PR TITLE
chore(mdn): Migrate the mdn redirector service over to refractr

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,6 @@
 JIRA ticket: [link to relevant JIRA or other system ticket]
 
 When creating a PR for Refractr, confirm you've done the following steps for smooth CI and CD experiences:
-- [ ] Is this the right place for your redirect (e.g. developer.mozilla.com/* redirects should be managed by MDN; other examples here as known)?
 - [ ] Have you updated the relevant YAML in the PR?
 - [ ] Have you checked the relevant YAML for any possible dupes regarding your domain?
 - [ ] Have you checked if there are any TLS cert concerns - e.g. if the domain being redirected already exists, and it is being changed to point at Refractr, is a temporary TLS 'outage' while waiting for Lets Encrypt certification via HTTP challenge okay? If not, [have you followed these steps for using DNS challenges with our cert-manager setup](https://mana.mozilla.org/wiki/display/SRE/Refractr+-+How+To+-+DNS+Challenges)?

--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -1216,3 +1216,19 @@ refracts:
 # SE-3620
 - blog.mozilla.org/en/mozilla/rise-25-winners/?source=web-redirect: rise25.mozilla.org
   status: 302
+
+# SE-3660
+- dsts:
+    - redirect: developer.mozilla.org
+  srcs:
+    - mozilla.dev
+    - www.mozilla.dev
+    - developer.mozilla.com
+    - wiki.developer.mozilla.org
+    - beta.developer.mozilla.org
+  tests:
+    - https://mozilla.dev/: "https://developer.mozilla.org/"
+    - https://www.mozilla.dev/: "https://developer.mozilla.org/"
+    - https://developer.mozilla.com/: "https://developer.mozilla.org/"
+    - https://wiki.developer.mozilla.org/foo: "https://developer.mozilla.org/foo"
+    - https://beta.developer.mozilla.org/foo: "https://developer.mozilla.org/foo"


### PR DESCRIPTION
## Refractr PR Checklist

JIRA ticket: [SE-3660](https://mozilla-hub.atlassian.net/browse/SE-3660)

Or I could create the redirects using the Gateway API in Kubernetes. This seems like the logical place, I'm not sure why it didn't exist over here already.
