### PR TITLE
chore: redirect rally domains to www.mozilla.org

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -1172,8 +1172,11 @@ refracts:
 # SE-3426
 - acorn.firefox.com/: design.firefox.com
 
-# DSRE-1301
-- rally.mozilla.org/: members.rally.mozilla.org
+- www.mozilla.org/:
+   # DSRE-1301
+  - members.rally.mozilla.org
+  # DSRE-1173
+  - rally.mozilla.org
 
 # 404 Hosts
 - nginx: |


### PR DESCRIPTION
(For 2024, marking as draft)

## Refractr PR Checklist

JIRA ticket: https://mozilla-hub.atlassian.net/browse/DSRE-1173

When creating a PR for Refractr, confirm you've done the following steps for smooth CI and CD experiences:
- [ ] Have you updated the relevant YAML in the PR?
- [ ] Have you checked the relevant YAML for any possible dupes regarding your domain?
- [ ] Have you checked if there are any TLS cert concerns - e.g. if the domain being redirected already exists, and it is being changed to point at Refractr, is a temporary TLS 'outage' while waiting for Lets Encrypt certification via HTTP challenge okay? If not, [have you followed these steps for using DNS challenges with our cert-manager setup](https://mana.mozilla.org/wiki/display/SRE/Refractr+-+How+To+-+DNS+Challenges)?
- [ ] If desired, have you generated the Nginx manually to confirm addition works as expected? 
- [ ] If desired, are you able to connect to EKS (cluster itse-apps-prod-1, namespace fluxcd) to more closely monitor the deploys?

After PR merge, next steps include:
- [ ] If going straight from main merge & Stage deploy to a release & production deploy, create the relevant GitHub release with an incremented version / tag applied.
- [ ] Confirm you are ready and able to perform the requested DNS creation or change post-deploy? 
