### PR TITLE
fixes se-3896: add explicit 404 for labs.mozilla.com and labs.mozilla.org

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -1253,3 +1253,10 @@ refracts:
 - developer.mozilla.org/en-US/docs/Games/:
   - openwebgames.com
   - www.openwebgames.com
+
+# SE-3896
+- nginx: |
+     server {
+       server_name labs.mozilla.org labs.mozilla.com;
+       return 404;
+     }


### PR DESCRIPTION
My intent is to create a rule that returns an explicit 404 for requests to `labs.mozilla.com` and `labs.mozilla.org`. I tried to match the example established by this range:
https://github.com/mozilla-it/refractr/blob/0446f9df6c68e68f80171630f3a252e99a56f95c/prod-refractr.yml#L1171-L1176


## Refractr PR Checklist

JIRA ticket: https://mozilla-hub.atlassian.net/browse/SE-3896

When creating a PR for Refractr, confirm you've done the following steps for smooth CI and CD experiences:
- [x] Have you updated the relevant YAML in the PR?
- [x] Have you checked the relevant YAML for any possible dupes regarding your domain?
- [x] Have you checked if there are any TLS cert concerns - e.g. if the domain being redirected already exists, and it is being changed to point at Refractr, is a temporary TLS 'outage' while waiting for Lets Encrypt certification via HTTP challenge okay? If not, [have you followed these steps for using DNS challenges with our cert-manager setup](https://mana.mozilla.org/wiki/display/SRE/Refractr+-+How+To+-+DNS+Challenges)?
---
- [ ] If desired, have you generated the Nginx manually to confirm addition works as expected? 
- [ ] If desired, are you able to connect to EKS (cluster itse-apps-prod-1, namespace fluxcd) to more closely monitor the deploys?

After PR merge, next steps include:
- [ ] If going straight from main merge & Stage deploy to a release & production deploy, create the relevant GitHub release with an incremented version / tag applied.
- [ ] Confirm you are ready and able to perform the requested DNS creation or change post-deploy? 
