### PR TITLE
fix se-3899: redirect games.mozilla.org to developer.mozilla.org/en-US/docs/Games/

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -1249,10 +1249,11 @@ refracts:
   - contributejson.org
   - www.contributejson.org
 
-# SE-3883
+# SE-3883, SE-3899
 - developer.mozilla.org/en-US/docs/Games/:
   - openwebgames.com
   - www.openwebgames.com
+  - games.mozilla.org
 
 # SE-3896
 - nginx: |


### PR DESCRIPTION
This already exists as a target, so I've added `games.mozilla.org` to the existing list and appended the ticket to the existing comment

## Refractr PR Checklist

JIRA ticket: [link to relevant JIRA or other system ticket]

When creating a PR for Refractr, confirm you've done the following steps for smooth CI and CD experiences:
- [x] Have you updated the relevant YAML in the PR?
- [x] Have you checked the relevant YAML for any possible dupes regarding your domain?
- [x] Have you checked if there are any TLS cert concerns - e.g. if the domain being redirected already exists, and it is being changed to point at Refractr, is a temporary TLS 'outage' while waiting for Lets Encrypt certification via HTTP challenge okay? If not, [have you followed these steps for using DNS challenges with our cert-manager setup](https://mana.mozilla.org/wiki/display/SRE/Refractr+-+How+To+-+DNS+Challenges)?
---
- [ ] If desired, have you generated the Nginx manually to confirm addition works as expected? 
- [ ] If desired, are you able to connect to EKS (cluster itse-apps-prod-1, namespace fluxcd) to more closely monitor the deploys?

After PR merge, next steps include:
- [ ] If going straight from main merge & Stage deploy to a release & production deploy, create the relevant GitHub release with an incremented version / tag applied.
- [ ] Confirm you are ready and able to perform the requested DNS creation or change post-deploy? 
