### PR TITLE
fix: redirect developer.cdn.mozilla.net permanently

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -126,14 +126,10 @@ refracts:
   - talkback-public.mozilla.org
   - talkback-reports.mozilla.org
 
-  # bug 695084
+  # bug 695084, SE-1571, MP-1163
 - developer.mozilla.org/:
   - dev.mozilla.org
-
-  # SE-1571
-- developer.mozilla.org/:
   - developer.cdn.mozilla.net
-  status: 302
 
   # bug 811323
 - developer.mozilla.org/demos/devderby/: devderby.mozilla.org


### PR DESCRIPTION
## Refractr PR Checklist

JIRA ticket: [MP-1163](https://mozilla-hub.atlassian.net/browse/MP-1163)

When creating a PR for Refractr, confirm you've done the following steps for smooth CI and CD experiences:
- [x] Have you updated the relevant YAML in the PR?
- [x] Have you checked the relevant YAML for any possible dupes regarding your domain?
- [x] Have you checked if there are any TLS cert concerns - e.g. if the domain being redirected already exists, and it is being changed to point at Refractr, is a temporary TLS 'outage' while waiting for Lets Encrypt certification via HTTP challenge okay? If not, [have you followed these steps for using DNS challenges with our cert-manager setup](https://mana.mozilla.org/wiki/display/SRE/Refractr+-+How+To+-+DNS+Challenges)?
- [ ] If desired, have you generated the Nginx manually to confirm addition works as expected? 
- [ ] If desired, are you able to connect to EKS (cluster itse-apps-prod-1, namespace fluxcd) to more closely monitor the deploys?

After PR merge, next steps include:
- [ ] If going straight from main merge & Stage deploy to a release & production deploy, create the relevant GitHub release with an incremented version / tag applied.
- [ ] Confirm you are ready and able to perform the requested DNS creation or change post-deploy? 
