### PR TITLE
fix: redirect hubs.mozilla.com to sumo article

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -344,6 +344,12 @@ refracts:
   # SE-1564
 - support.mozilla.org/en-US/kb/canary-domain-use-application-dnsnet:  use-application-dns.net
 
+  # SVCSE-1946
+- support.mozilla.org/en-US/kb/end-support-mozilla-hubs:
+    - hubs.mozilla.org
+    - hubs.mozilla.com
+    - hubs.mozilla.com/labs/
+
   # SVCSE-1316
 - dsts:
     - /downloads/browser/latest/secure-proxy.xpi: archive.mozilla.org/pub/vpn/fpn/secure-proxy.xpi

--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -190,11 +190,6 @@ refracts:
   - popcornjs.org
   - www.popcornjs.org
 
-  # bug 1462137
-- hubs.mozilla.com/:
-  - hub.mozilla.com
-  - hub.mozilla.org
-
   # bug 784556, 880423
 - mana.mozilla.org/wiki/display/SD/print.mozilla.com/: print.mozilla.com
 
@@ -348,7 +343,7 @@ refracts:
 - support.mozilla.org/en-US/kb/end-support-mozilla-hubs:
     - hubs.mozilla.org
     - hubs.mozilla.com
-    - hubs.mozilla.com/labs/
+    - mixedreality.mozilla.org
 
   # SVCSE-1316
 - dsts:
@@ -1136,9 +1131,6 @@ refracts:
 
 # IO-2308 redirect webdx to fxdx
 - fxdx.dev/: webdx.dev
-
-# SE-3415 Redirect mixedreality.mozilla.org to hubs.mozilla.com/labs/
-- hubs.mozilla.com/labs/: mixedreality.mozilla.org
 
 # OPST-277 Redirect mdn.mozillademos.org/* to mdn.dev/archives/media/*
 - dsts:


### PR DESCRIPTION
## Refractr PR Checklist

JIRA ticket: https://mozilla-hub.atlassian.net/browse/SVCSE-1946

When creating a PR for Refractr, confirm you've done the following steps for smooth CI and CD experiences:
- [ ] Have you updated the relevant YAML in the PR?
- [ ] Have you checked the relevant YAML for any possible dupes regarding your domain?
- [ ] Have you checked if there are any TLS cert concerns - e.g. if the domain being redirected already exists, and it is being changed to point at Refractr, is a temporary TLS 'outage' while waiting for Lets Encrypt certification via HTTP challenge okay? If not, [have you followed these steps for using DNS challenges with our cert-manager setup](https://mana.mozilla.org/wiki/display/SRE/Refractr+-+How+To+-+DNS+Challenges)?
- [ ] If desired, have you generated the Nginx manually to confirm addition works as expected? 
- [ ] If desired, are you able to connect to EKS (cluster itse-apps-prod-1, namespace fluxcd) to more closely monitor the deploys?

After PR merge, next steps include:
- [ ] If going straight from main merge & Stage deploy to a release & production deploy, create the relevant GitHub release with an incremented version / tag applied.
- [ ] Confirm you are ready and able to perform the requested DNS creation or change post-deploy? 
