### PR TITLE
fix(codeowners): Add @mozilla teams to prep for move

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-* @mozilla-it/sre-wg
-prod-refractr.yml @mozilla-it/it-infrastructure-wg @mozilla-it/sre-wg
+* @mozilla/sre-wg @mozilla-it/sre-wg
+prod-refractr.yml @mozilla/it-infrastructure-wg @mozilla/sre-wg @mozilla-it/it-infrastructure-wg @mozilla-it/sre-wg


### PR DESCRIPTION
## Refractr PR Checklist
This PR adds the @mozilla equivalent teams so that reviews will continue to work before and after moving this repository to the Mozilla org.


JIRA ticket: https://mozilla-hub.atlassian.net/browse/MZCLD-2266 

When creating a PR for Refractr, confirm you've done the following steps for a smooth CI and CD experience:
- [ ] Have you updated the relevant YAML in the PR?
- [ ] Have you checked the relevant YAML for any possible dupes regarding your domain?
- [ ] Have you checked if there are any TLS cert concerns - e.g. if the domain being redirected already exists, and it is being changed to point at refractr, is a temporary TLS 'outage' while waiting for certification via HTTP challenge okay? If not, add a note to the JIRA ticket.
- [ ] If desired, have you generated the nginx config manually to confirm updates work as expected?

After PR merge:
- [ ] A merge to `main` automatically deploys both stage and prod.
- [ ] TLS certificates are created automatically by [Spacelift](https://mozilla.app.spacelift.io/stack/refractr-prod). DNS changes may still require SRE or IT to make changes in other systems (e.g. Markmonitor, Route53) -- ask in #mozcloud-support on Slack or in the JIRA ticket.
