### PR TITLE
fix(codeowners): Remove @mozilla-it teams after move

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-* @mozilla/sre-wg @mozilla-it/sre-wg
-prod-refractr.yml @mozilla/it-infrastructure-wg @mozilla/sre-wg @mozilla-it/it-infrastructure-wg @mozilla-it/sre-wg
+* @mozilla/sre-wg
+prod-refractr.yml @mozilla/it-infrastructure-wg @mozilla/sre-wg

--- a/docs/refractr-architecture.md
+++ b/docs/refractr-architecture.md
@@ -44,7 +44,7 @@ The handoff point between CI and CD is the Docker Repository. In this case we de
 Refractr's dependencies are managed with [poetry](https://python-poetry.org/). In order to interact with the system locally, having poetry installed and setup is a requirement. Once tools are in place, a simple `$ poetry install` in the repo's base dir is enough to get started. From here on forward, `$ poetry shell` can be used to prepare your open shell session for interacting with the system directly. It is also possible to prepend commands with `$ poetry run`.
 
 ## Doit Automation (like Make)
-The **mozilla-it/refractr** repository has a **dodo.py** ([doit](https://pydoit.org/)) that defines the list of tasks that can be performed. This approach was chosen to allow the developer to run the same automation at their desk as what is run during CI. This promotes tight feedback loops for the developers and confidence that once the changes are pushed they are most likely to succeed because they have already run them locally. Below is the output of the **doit list** command.
+The **mozilla/refractr** repository has a **dodo.py** ([doit](https://pydoit.org/)) that defines the list of tasks that can be performed. This approach was chosen to allow the developer to run the same automation at their desk as what is run during CI. This promotes tight feedback loops for the developers and confidence that once the changes are pushed they are most likely to succeed because they have already run them locally. Below is the output of the **doit list** command.
 
 ```sh
 $ poetry run doit list
@@ -114,7 +114,7 @@ This task generates a yaml document that is suitable for refractr's infrastructu
 ## Refractr CLI
 The **refractr cli** is an Argparse command tool to transform the **refractr.yml** to the **refractr.conf** (for nginx). This tool was written to print output of transformations to terminal.  This allows the user to "see" what the transformations will do.  The same fascilities will be used during the build of the docker image.  The help output is shown below will all of the subcommands described.
 ```
-~/repos/mozilla-it/refractr > bin/refractr --help
+~/repos/mozilla/refractr > bin/refractr --help
 usage: refractr [-h] [-c CFG] [-o OUPUT] {show,sh,domains,do,certificate_manager_input,cmi,nginx,ngx,ingress,ing,validate,val} ...
 
 refractr

--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -309,7 +309,7 @@ refracts:
     - /downloads/browser/latest/secure-proxy.xpi: archive.mozilla.org/pub/vpn/fpn/secure-proxy.xpi
     - /downloads/browser/updates.json: archive.mozilla.org/pub/vpn/fpn/updates.json
     # Needs to start with ^/ to switch from `location = /` to `location /`
-    # https://github.com/mozilla-it/refractr/blob/80c019c468bb8ad6633bc5d53e6b154d8142dd6c/refractr/complex.py#L159-L160
+    # https://github.com/mozilla/refractr/blob/80c019c468bb8ad6633bc5d53e6b154d8142dd6c/refractr/complex.py#L159-L160
     - ^/(.*): support.mozilla.org/kb/firefox-private-network-no-longer-available?utm_source=inproduct&utm_medium=support
   srcs:
     - fpn.firefox.com


### PR DESCRIPTION
## Refractr PR Checklist
This PR removes @mozilla-it teams after move

JIRA ticket: MZCLD-2266

When creating a PR for Refractr, confirm you've done the following steps for a smooth CI and CD experience:
- [ ] Have you updated the relevant YAML in the PR?
- [ ] Have you checked the relevant YAML for any possible dupes regarding your domain?
- [ ] Have you checked if there are any TLS cert concerns - e.g. if the domain being redirected already exists, and it is being changed to point at refractr, is a temporary TLS 'outage' while waiting for certification via HTTP challenge okay? If not, add a note to the JIRA ticket.
- [ ] If desired, have you generated the nginx config manually to confirm updates work as expected?

After PR merge:
- [ ] A merge to `main` automatically deploys both stage and prod.
- [ ] TLS certificates are created automatically by [Spacelift](https://mozilla.app.spacelift.io/stack/refractr-prod). DNS changes may still require SRE or IT to make changes in other systems (e.g. Markmonitor, Route53) -- ask in #mozcloud-support on Slack or in the JIRA ticket.
