### PR TITLE
chore(precommit): Adding workflow to run pre-commit with the merge_gr…

### DIFF
--- a/.github/workflows/merge-queue.yaml
+++ b/.github/workflows/merge-queue.yaml
@@ -1,0 +1,18 @@
+name: merge-group
+
+on:
+  merge_group: {}
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@v6
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - name: Install pre-commit
+        shell: bash
+        run: uv tool install pre-commit --with pre-commit-uv
+      - run: pre-commit run --show-diff-on-failure --color=always --all-files
+        shell: bash


### PR DESCRIPTION
Adding a new workflow to run `pre-commit` with the `merge_group` trigger. 

As of 04/27, the `refractr` ruleset was updated in `global-platform-admin` to require the `merge_queue` trigger  - [PR](https://github.com/mozilla/global-platform-admin/commit/6c9db091c211988aef6f99bf44b82366c58795a8#diff-b0638c6d5dcba7d797ea76a5895b115b418b72c82fea75d2bf54d9a735aa42e9R98)

This PR creates a new workflow, with `pre-commit` similar to:
- https://github.com/mozilla/webservices-infra/blob/main/.github/workflows/merge-queue.yaml
- https://github.com/mozilla/global-platform-admin/blob/main/.github/workflows/merge-queue.yaml

This specifically unblocked @bkochendorfer 's [PR](https://github.com/mozilla/refractr/pull/433).