### PR TITLE
Move firefox.com apex redirect from 302 to 301, WT-1224

### DIFF
--- a/prod-refractr.yml
+++ b/prod-refractr.yml
@@ -862,10 +862,9 @@ refracts:
 - www.mozilla.org/: status.mozilla.org
   status: 302
 
-#  SE-3189 then updated by SREIN-32
+#  SE-3189 then updated by SREIN-32, WT-1224
 - www.firefox.com/:
   - firefox.com
-  status: 302 # Consider removing after discussion with SEO team
 
 # SE-3189, SREIN-32
 - www.firefox.com/:


### PR DESCRIPTION
This was originally added as 302 in case it needed tweaking. It aged well and could use 301 now.

## Refractr PR Checklist

JIRA ticket: WT-1224

When creating a PR for Refractr, confirm you've done the following steps for a smooth CI and CD experience:
- [x] Have you updated the relevant YAML in the PR?
- [x] Have you checked the relevant YAML for any possible dupes regarding your domain?
- [x] Have you checked if there are any TLS cert concerns - e.g. if the domain being redirected already exists, and it is being changed to point at refractr, is a temporary TLS 'outage' while waiting for certification via HTTP challenge okay? If not, add a note to the JIRA ticket.
- [ ] If desired, have you generated the nginx config manually to confirm updates work as expected?

After PR merge:
- [ ] A merge to `main` automatically deploys both stage and prod.
- [ ] TLS certificates are created automatically by [Spacelift](https://mozilla.app.spacelift.io/stack/refractr-prod). DNS changes may still require SRE or IT to make changes in other systems (e.g. Markmonitor, Route53) -- ask in #mozcloud-support on Slack or in the JIRA ticket.