### PR TITLE
Bump versions in builder CI

### DIFF
--- a/.github/workflows/build_and_push_to_gar.yml
+++ b/.github/workflows/build_and_push_to_gar.yml
@@ -11,8 +11,8 @@ on:
       - v[0-9]+.[0-9]+.[0-9]+
 
 env:
-  POETRY_VERSION: 1.8.3
-  PYTHON_VERSION: 3.11.10
+  POETRY_VERSION: 1.8.5
+  PYTHON_VERSION: 3.11.15
 
 jobs:
   build-and-push:

--- a/.github/workflows/build_and_push_to_gar.yml
+++ b/.github/workflows/build_and_push_to_gar.yml
@@ -1,4 +1,3 @@
----
 name: build and push to GAR
 on:
   push:
@@ -27,7 +26,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -35,7 +34,7 @@ jobs:
         run: python -m pip install poetry==${{ env.POETRY_VERSION }}
 
       - name: setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: poetry
@@ -53,24 +52,24 @@ jobs:
         run: |-
           echo TAG=$(git describe --tags --abbrev=7) |tee -a ${GITHUB_OUTPUT}
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - id: gcp-auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           token_format: access_token
           service_account: artifact-writer@${{ secrets.GAR_PROJECT_ID }}.iam.gserviceaccount.com
           workload_identity_provider: projects/${{ secrets.WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/github-actions/providers/github-actions
 
       - id: docker-login
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: us-docker.pkg.dev
           username: oauth2accesstoken
           password: ${{ steps.gcp-auth.outputs.access_token }}
 
       - id: build-and-push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: refractr/
           tags: |


### PR DESCRIPTION
Upgrades deprecated actions that raise warnings about runner compatibility.

(Bumps the Python env versions to the latest on the same major+minor as well while at it.)

## Refractr PR Checklist

JIRA ticket: 🚫🐞